### PR TITLE
fix unintended octal literal in convertToMS.test.js

### DIFF
--- a/tests/convertToMS.test.js
+++ b/tests/convertToMS.test.js
@@ -6,7 +6,7 @@ var convertToMS = require("../controllers/convertToMS");
 describe("convertToMS", function(){
   // Checking invalid types: Number
   it("Should return 'Invalid Date' when passed 0120", function(){
-    convertToMS(0120).should.equal("Invalid Date");
+    convertToMS(120).should.equal("Invalid Date");
   })
   // Checking invalid types: Boolean
   it("Should return 'Invalid Date' when passed true", function(){


### PR DESCRIPTION
A leading 0 causes `0120` to be evaluated as an octal literal resulting in `80`, but according to the test description, the number `120` was intended.

(The use of a leading `0` to denote an octal is a legacy syntax feature, now replaced by a  leading `0o`. While working on the eslint configuration, I found the legacy octal syntax caused this file to fail to be parsed by eslint because they no longer support it)