### PR TITLE
Add eslint configuration and scripts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "extends": ["standard"],
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+    "comma-dangle": ["error", "always-multiline"],
+    "object-curly-spacing": ["error", "always"],
+    "semi": ["error", "always"],
+    "space-before-function-paren": ["error", {
+      "anonymous": "always",
+      "named": "never",
+      "asyncArrow": "always"
+    }]
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
       "anonymous": "always",
       "named": "never",
       "asyncArrow": "always"
-    }]
+    }],
+    "space-in-parens": ["error", "always"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Development version of the Pairboard app. This currently has no live hosting or 
 
 In both cases, `npm start` will launch client and server concurrently. 
 There is no need to run them in separate terminals.
+
+## Linting
+
+This repo has its very own eslint config. To run eslint from the command line `npm run lint`. The client and the server must be linted separately because of differing dependencies, to lint the server, run the command from the root, to lint the client, run the command from `/client`.
+
+Many linting rules can be automatically fixed by eslint. `npm run lint-fix` to automatically fix all fixable linting errors. Again, this must be run separately for the client and server.
+
+Please lint your code before submitting a pull request.
+
+It is recommended you install a linting plugin for your code editor and enable automatic fix on save. For atom this is [linter-eslint](https://atom.io/packages/linter-eslint).

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": ["../.eslintrc", "plugin:react/recommended"],
+  "plugins": [
+    "react"
+  ],
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "node": false
+  },
+  "rules": {
+    "jsx-quotes": ["error", "prefer-double"],
+    "react/jsx-indent": ["error", 2]
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint .",
+    "lint-fix": "eslint --fix ."
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,11 @@
   "proxy": "http://localhost:3001/",
   "devDependencies": {
     "body-parser": "^1.15.2",
+    "eslint": "^3.12.2",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-standard": "^2.0.1",
     "express": "^4.14.0",
     "react-scripts": "0.7.0"
   },

--- a/client/server/.eslintrc
+++ b/client/server/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "../.eslintrc",
+  "env": {
+    "browser": false,
+    "commonjs": false,
+    "node": true,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "concurrently": "^3.1.0",
+    "eslint": "^3.12.2",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.4.0",
+    "eslint-plugin-standard": "^2.0.1",
     "expect": "^1.20.2",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start-lite": "concurrently \"npm run server\" \"npm run client\" \"node client/server/server\"",
     "server": "node server.js",
     "client": "node start-client.js",
-    "first": "npm install && cd client && npm install && cd .. && cp config/config_template.json config/config.json"
+    "first": "npm install && cd client && npm install && cd .. && cp config/config_template.json config/config.json",
+    "lint": "eslint \"*.js\" \"!(client)/**/*.js\"",
+    "lint-fix": "eslint --fix \"*.js\" \"!(client)/**/*.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This eslint configuration extends [standard](https://github.com/feross/standard), but with the following additions/changes:
- semicolons after every statement
- dangling commas for multiline objects, arrays, and object-like patterns (destructuring, named imports)
- spaces padding objects `{ prop: 'val' }`
- no space between function name and param list, a space between the function keyword and the param list for anonymous functions, a space after the async keyword for async arrow functions
- spaces padding parentheses `console.log( arg1, arg2 )`
- double quotes for string literals in jsx, single quotes everywhere else (except to avoid escaping)

There are also two new scripts, `lint` and `lint-fix`. `lint` reports eslint errors, and `lint-fix` will fix automatically fixable problems such as missing semicolons. For the purposes of linting, the client and server are separate, you must `lint` from within the client folder to lint client files and within the root folder to lint server files.

Resist the urge to commit style fixes for the current repo, we'll do that in one big go. For now just make sure anything you write new is valid.

A lint check should probably be added to the ci but I don't know how to do that 😅 