### PR TITLE
[client] fix eslint errors

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -11,5 +11,8 @@
   "rules": {
     "jsx-quotes": ["error", "prefer-double"],
     "react/jsx-indent": ["error", 2]
+  },
+  "globals": {
+    "process": false
   }
 }

--- a/client/server/convertToMS.js
+++ b/client/server/convertToMS.js
@@ -3,7 +3,7 @@ module.exports = ( string ) => {
   if ( typeof string === 'string' ) {
     var regex = /\d{1,2}:\d{2}/;
     // Check if there is a match and if the input is equal to this match
-    if ( string.match( regex ) && string.match( regex )[0] == string ) {
+    if ( string.match( regex ) && string.match( regex )[0] === string ) {
       var arr = string.split( ':' );
       var time = ( +arr[0] * 3600000 ) + ( +arr[1] * 60000 );
       return time;

--- a/client/server/server.js
+++ b/client/server/server.js
@@ -17,7 +17,6 @@ app.use( function ( req, res, next ) {
 } );
 
 app.get( '/api/v1/posts', ( req, res ) => {
-  let idList = campers.map( i => i._id );
   res.send( campers );
 } );
 
@@ -30,7 +29,9 @@ app.post( '/api/v1/posts', ( req, res ) => {
     _id: '1234567890' + offset,
     postTime: new Date().getTime(),
     endTime: new Date().getTime() + endTime,
-    username, setup, interests,
+    username,
+    setup,
+    interests,
   };
   campers.push( newPost );
   res.status( 201 ).send( { status: 201, data: newPost } );
@@ -40,7 +41,7 @@ app.post( '/api/v1/posts', ( req, res ) => {
 app.post( '/api/v1/:id', ( req, res ) => {
   var id = req.params.id;
   for ( let i in campers ) {
-    if ( campers[i]._id == id ) {
+    if ( campers[i]._id === id ) {
       campers.splice( i, 1 );
       return res.redirect( 'http://localhost:3000' );
     }
@@ -53,7 +54,7 @@ app.post( '/api/v1/:id', ( req, res ) => {
 app.delete( '/api/v1/posts/:id', ( req, res ) => {
   var id = req.params.id;
   for ( let i in campers ) {
-    if ( campers[i]._id == id ) {
+    if ( campers[i]._id === id ) {
       campers.splice( i, 1 );
       res.status( 204 ).send();
     }


### PR DESCRIPTION
Some of the fixes were replacing the loose equality operator `==` with the strict equality operator `===`. They are not interchangeable and this has the potential to introduce unintended logic, however it doesn't seem that it would cause any changes from the code I've read.

Also closes https://github.com/Pairboard/Pairboard/issues/8.

Together with https://github.com/Pairboard/Pairboard/pull/15, these are the last of the eslint errors in the client code.