### PR TITLE
regenerated package-lock, small fixes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.20",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -26,7 +26,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -48,8 +48,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -82,7 +82,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-flatten": {
@@ -97,7 +97,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -112,8 +112,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.12.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "arraybuffer.slice": {
@@ -146,9 +146,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "js-tokens": {
@@ -164,8 +164,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -211,15 +211,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -228,7 +228,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -239,7 +239,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -261,7 +261,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsite": {
@@ -281,11 +281,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "circular-json": {
@@ -305,7 +305,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -353,10 +353,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "content-disposition": {
@@ -399,9 +399,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "d": {
@@ -410,7 +410,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.46"
+        "es5-ext": "^0.10.9"
       }
     },
     "date-fns": {
@@ -438,7 +438,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.0.12"
+        "object-keys": "^1.0.12"
       }
     },
     "del": {
@@ -447,13 +447,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "depd": {
@@ -474,7 +474,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-helpers": {
@@ -499,7 +499,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "~0.4.13"
       }
     },
     "engine.io-client": {
@@ -516,7 +516,7 @@
         "parsejson": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "1.1.5",
+        "ws": "~1.1.5",
         "xmlhttprequest-ssl": "1.5.3",
         "yeast": "0.1.2"
       },
@@ -555,11 +555,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -568,9 +568,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -579,9 +579,9 @@
       "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
@@ -590,9 +590,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -601,12 +601,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -615,11 +615,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -628,8 +628,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -638,10 +638,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -662,10 +662,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -674,41 +674,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "doctrine": "2.1.0",
-        "escope": "3.6.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.3",
-        "globals": "9.18.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.19.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.11",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       }
     },
     "eslint-config-standard": {
@@ -729,11 +729,11 @@
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.3",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.1.0"
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
       },
       "dependencies": {
         "doctrine": {
@@ -742,8 +742,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "isarray": {
@@ -766,8 +766,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -782,7 +782,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -791,7 +791,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -818,8 +818,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.46"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "exit-hook": {
@@ -834,36 +834,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.4",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "body-parser": {
@@ -873,15 +873,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.3",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "1.6.16"
+            "type-is": "~1.6.15"
           }
         },
         "iconv-lite": {
@@ -923,7 +923,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.3.1 < 2"
               }
             },
             "setprototypeof": {
@@ -959,13 +959,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.18"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
       }
     },
     "figures": {
@@ -974,8 +974,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -984,8 +984,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "finalhandler": {
@@ -995,12 +995,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -1017,10 +1017,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "follow-redirects": {
@@ -1028,7 +1028,7 @@
       "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
       "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.2.0"
       }
     },
     "forwarded": {
@@ -1056,8 +1056,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.11.1",
-        "node-pre-gyp": "0.6.29"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.29"
       },
       "dependencies": {
         "abbrev": {
@@ -1089,8 +1089,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.1.4"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.0 || ^1.1.13"
           }
         },
         "asn1": {
@@ -1134,7 +1134,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "readable-stream": "2.0.6"
+            "readable-stream": "~2.0.5"
           },
           "dependencies": {
             "readable-stream": {
@@ -1143,12 +1143,12 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.1",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               }
             }
           }
@@ -1158,7 +1158,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.1"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -1166,7 +1166,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -1174,7 +1174,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -1195,11 +1195,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -1207,7 +1207,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.0"
+            "number-is-nan": "^1.0.0"
           }
         },
         "combined-stream": {
@@ -1215,7 +1215,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -1224,7 +1224,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "concat-map": {
@@ -1248,7 +1248,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -1257,7 +1257,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1300,7 +1300,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.0"
+            "jsbn": "~0.1.0"
           }
         },
         "escape-string-regexp": {
@@ -1332,9 +1332,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "1.5.2",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.11"
+            "async": "^1.5.2",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.10"
           }
         },
         "fs.realpath": {
@@ -1347,10 +1347,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.4",
-            "inherits": "2.0.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.3"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -1359,9 +1359,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.10",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.2"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -1370,15 +1370,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.0.4",
-            "console-control-strings": "1.1.0",
-            "has-color": "0.1.7",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.0",
-            "signal-exit": "3.0.0",
-            "string-width": "1.0.1",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.0"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-color": "^0.1.7",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "generate-function": {
@@ -1393,7 +1393,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-property": "1.0.2"
+            "is-property": "^1.0.0"
           }
         },
         "getpass": {
@@ -1402,7 +1402,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1418,12 +1418,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.5",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.2",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -1443,10 +1443,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.13.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "has-ansi": {
@@ -1455,7 +1455,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-color": {
@@ -1476,10 +1476,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -1493,9 +1493,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.3.0",
-            "sshpk": "1.8.3"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -1503,8 +1503,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.3.3",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1523,7 +1523,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.0"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-my-json-valid": {
@@ -1532,10 +1532,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
             "jsonpointer": "2.0.0",
-            "xtend": "4.0.1"
+            "xtend": "^4.0.0"
           }
         },
         "is-property": {
@@ -1567,7 +1567,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.0"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -1615,7 +1615,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.23.0"
+            "mime-db": "~1.23.0"
           }
         },
         "minimatch": {
@@ -1623,7 +1623,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.5"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -1651,15 +1651,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "3.1.2",
-            "rc": "1.1.6",
-            "request": "2.73.0",
-            "rimraf": "2.5.3",
-            "semver": "5.2.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.1.4"
+            "mkdirp": "~0.5.0",
+            "nopt": "~3.0.1",
+            "npmlog": "~3.1.2",
+            "rc": "~1.1.0",
+            "request": "2.x",
+            "rimraf": "~2.5.0",
+            "semver": "~5.2.0",
+            "tar": "~2.2.0",
+            "tar-pack": "~3.1.0"
           }
         },
         "node-uuid": {
@@ -1674,7 +1674,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           }
         },
         "npmlog": {
@@ -1683,10 +1683,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.6.0",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.6.0",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -1711,7 +1711,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -1731,7 +1731,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "process-nextick-args": {
@@ -1751,10 +1751,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.1",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "1.0.4"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
           },
           "dependencies": {
             "minimist": {
@@ -1770,13 +1770,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -1785,27 +1785,27 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.4.1",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.0-rc4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.11",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.0",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.2",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc4",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "rimraf": {
@@ -1813,7 +1813,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.0.5"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -1840,7 +1840,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -1849,14 +1849,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "dashdash": "1.14.0",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.6",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.0",
-            "tweetnacl": "0.13.3"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.13.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1872,9 +1872,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.0.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -1893,7 +1893,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -1913,9 +1913,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.10",
-            "inherits": "2.0.1"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -1924,14 +1924,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.2.0",
-            "fstream": "1.0.10",
-            "fstream-ignore": "1.0.5",
-            "once": "1.3.3",
-            "readable-stream": "2.1.4",
-            "rimraf": "2.5.3",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "~2.2.0",
+            "fstream": "~1.0.10",
+            "fstream-ignore": "~1.0.5",
+            "once": "~1.3.3",
+            "readable-stream": "~2.1.4",
+            "rimraf": "~2.5.1",
+            "tar": "~2.2.1",
+            "uid-number": "~0.0.6"
           }
         },
         "tough-cookie": {
@@ -1978,7 +1978,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.1"
+            "string-width": "^1.0.1"
           }
         },
         "wrappy": {
@@ -2006,7 +2006,7 @@
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.2"
       }
     },
     "generate-object-property": {
@@ -2015,7 +2015,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "glob": {
@@ -2024,12 +2024,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -2044,12 +2044,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.3",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -2064,7 +2064,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -2073,7 +2073,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary": {
@@ -2100,10 +2100,10 @@
       "resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
       "integrity": "sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=",
       "requires": {
-        "invariant": "2.2.4",
-        "loose-envify": "1.4.0",
-        "query-string": "4.3.4",
-        "warning": "3.0.0"
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "query-string": "^4.2.2",
+        "warning": "^3.0.0"
       }
     },
     "hoist-non-react-statics": {
@@ -2117,10 +2117,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "iconv-lite": {
@@ -2128,7 +2128,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -2154,8 +2154,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2170,19 +2170,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.11",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "interpret": {
@@ -2196,7 +2196,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -2223,7 +2223,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
@@ -2238,11 +2238,11 @@
       "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
-        "generate-function": "2.3.1",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-path-cwd": {
@@ -2257,7 +2257,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2266,7 +2266,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-property": {
@@ -2281,7 +2281,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -2301,7 +2301,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "isarray": {
@@ -2314,8 +2314,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "3.0.0"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "js-tokens": {
@@ -2329,8 +2329,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-stable-stringify": {
@@ -2339,7 +2339,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json3": {
@@ -2376,8 +2376,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -2390,7 +2390,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "media-typer": {
@@ -2429,7 +2429,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "minimatch": {
@@ -2438,7 +2438,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2497,8 +2497,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "number-is-nan": {
@@ -2529,10 +2529,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.12"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "on-finished": {
@@ -2550,7 +2550,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -2565,12 +2565,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "options": {
@@ -2589,7 +2589,7 @@
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseqs": {
@@ -2597,7 +2597,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -2605,7 +2605,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -2656,7 +2656,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -2688,7 +2688,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -2696,8 +2696,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "proxy-addr": {
@@ -2706,7 +2706,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -2721,8 +2721,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "range-parser": {
@@ -2749,7 +2749,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -2759,11 +2759,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "15.6.3",
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-bootstrap": {
@@ -2771,16 +2771,16 @@
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.10.tgz",
       "integrity": "sha1-27ppCVlfKvTZGTfbD5bsjC3y0ag=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.6",
-        "dom-helpers": "3.3.1",
-        "invariant": "2.2.4",
-        "keycode": "2.2.0",
-        "prop-types": "15.6.2",
-        "react-overlays": "0.6.12",
-        "react-prop-types": "0.4.0",
-        "uncontrollable": "4.1.0",
-        "warning": "3.0.0"
+        "babel-runtime": "^6.11.6",
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "invariant": "^2.2.1",
+        "keycode": "^2.1.2",
+        "prop-types": "^15.5.6",
+        "react-overlays": "^0.6.12",
+        "react-prop-types": "^0.4.0",
+        "uncontrollable": "^4.0.1",
+        "warning": "^3.0.0"
       }
     },
     "react-dom": {
@@ -2788,10 +2788,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-overlays": {
@@ -2799,10 +2799,10 @@
       "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
       "integrity": "sha1-oHnHUMxCnX20x0dKlbS1QDPiVcM=",
       "requires": {
-        "classnames": "2.2.6",
-        "dom-helpers": "3.3.1",
-        "react-prop-types": "0.4.0",
-        "warning": "3.0.0"
+        "classnames": "^2.2.5",
+        "dom-helpers": "^3.2.0",
+        "react-prop-types": "^0.4.0",
+        "warning": "^3.0.0"
       }
     },
     "react-prop-types": {
@@ -2810,7 +2810,7 @@
       "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
       "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
       "requires": {
-        "warning": "3.0.0"
+        "warning": "^3.0.0"
       }
     },
     "react-router": {
@@ -2818,13 +2818,13 @@
       "resolved": "http://registry.npmjs.org/react-router/-/react-router-3.2.1.tgz",
       "integrity": "sha512-SXkhC0nr3G0ltzVU07IN8jYl0bB6FsrDIqlLC9dK3SITXqyTJyM7yhXlUqs89w3Nqi5OkXsfRUeHX+P874HQrg==",
       "requires": {
-        "create-react-class": "15.6.3",
-        "history": "3.3.0",
-        "hoist-non-react-statics": "2.5.5",
-        "invariant": "2.2.4",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.6.2",
-        "warning": "3.0.0"
+        "create-react-class": "^15.5.1",
+        "history": "^3.0.0",
+        "hoist-non-react-statics": "^2.3.1",
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "prop-types": "^15.5.6",
+        "warning": "^3.0.0"
       }
     },
     "react-scripts": {
@@ -2838,7 +2838,7 @@
         "babel-eslint": "7.0.0",
         "babel-jest": "16.0.0",
         "babel-loader": "6.2.5",
-        "babel-preset-react-app": "1.0.0",
+        "babel-preset-react-app": "^1.0.0",
         "case-sensitive-paths-webpack-plugin": "1.1.4",
         "chalk": "1.1.3",
         "connect-history-api-fallback": "1.3.0",
@@ -2847,7 +2847,7 @@
         "detect-port": "1.0.1",
         "dotenv": "2.0.0",
         "eslint": "3.8.1",
-        "eslint-config-react-app": "0.3.0",
+        "eslint-config-react-app": "^0.3.0",
         "eslint-loader": "1.6.0",
         "eslint-plugin-flowtype": "2.21.0",
         "eslint-plugin-import": "2.0.1",
@@ -2868,7 +2868,7 @@
         "path-exists": "2.1.0",
         "postcss-loader": "1.0.0",
         "promise": "7.1.1",
-        "react-dev-utils": "0.3.0",
+        "react-dev-utils": "^0.3.0",
         "recursive-readdir": "2.1.0",
         "rimraf": "2.5.4",
         "strip-ansi": "3.0.1",
@@ -2900,7 +2900,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-types": "2.1.12",
+            "mime-types": "~2.1.11",
             "negotiator": "0.6.1"
           }
         },
@@ -2914,7 +2914,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "acorn": "2.7.0"
+            "acorn": "^2.1.0"
           },
           "dependencies": {
             "acorn": {
@@ -2929,7 +2929,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "acorn": "3.3.0"
+            "acorn": "^3.0.4"
           },
           "dependencies": {
             "acorn": {
@@ -2944,8 +2944,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ajv-keywords": {
@@ -2958,9 +2958,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.0.4",
-            "longest": "1.0.1",
-            "repeat-string": "1.5.4"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "alphanum-sort": {
@@ -2998,8 +2998,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11"
+            "arrify": "^1.0.0",
+            "micromatch": "^2.1.5"
           }
         },
         "append-transform": {
@@ -3012,7 +3012,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
@@ -3020,7 +3020,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.0.1"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -3048,7 +3048,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "array-uniq": {
@@ -3109,12 +3109,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "browserslist": "1.4.0",
-            "caniuse-db": "1.0.30000564",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "~1.4.0",
+            "caniuse-db": "^1.0.30000554",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.4",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "aws-sign2": {
@@ -3132,9 +3132,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "2.0.0"
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^2.0.0"
           }
         },
         "babel-core": {
@@ -3142,27 +3142,27 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.16.0",
-            "babel-generator": "6.17.0",
-            "babel-helpers": "6.16.0",
-            "babel-messages": "6.8.0",
-            "babel-register": "6.16.3",
-            "babel-runtime": "6.11.6",
-            "babel-template": "6.16.0",
-            "babel-traverse": "6.16.0",
-            "babel-types": "6.16.0",
-            "babylon": "6.13.0",
-            "convert-source-map": "1.3.0",
-            "debug": "2.2.0",
-            "json5": "0.4.0",
-            "lodash": "4.16.4",
-            "minimatch": "3.0.3",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.6",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.6"
+            "babel-code-frame": "^6.16.0",
+            "babel-generator": "^6.17.0",
+            "babel-helpers": "^6.16.0",
+            "babel-messages": "^6.8.0",
+            "babel-register": "^6.16.0",
+            "babel-runtime": "^6.9.1",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^2.1.1",
+            "json5": "^0.4.0",
+            "lodash": "^4.2.0",
+            "minimatch": "^3.0.2",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0"
           },
           "dependencies": {
             "path-exists": {
@@ -3177,10 +3177,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-traverse": "6.16.0",
-            "babel-types": "6.16.0",
-            "babylon": "6.13.0",
-            "lodash.pickby": "4.6.0"
+            "babel-traverse": "^6.15.0",
+            "babel-types": "^6.15.0",
+            "babylon": "^6.11.2",
+            "lodash.pickby": "^4.6.0"
           }
         },
         "babel-generator": {
@@ -3188,13 +3188,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.8.0",
-            "babel-runtime": "6.11.6",
-            "babel-types": "6.16.0",
-            "detect-indent": "3.0.1",
-            "jsesc": "1.3.0",
-            "lodash": "4.16.4",
-            "source-map": "0.5.6"
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.16.0",
+            "detect-indent": "^3.0.1",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0"
           }
         },
         "babel-helpers": {
@@ -3202,8 +3202,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.11.6",
-            "babel-template": "6.16.0"
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.16.0"
           }
         },
         "babel-jest": {
@@ -3211,9 +3211,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-core": "6.17.0",
-            "babel-plugin-istanbul": "2.0.3",
-            "babel-preset-jest": "16.0.0"
+            "babel-core": "^6.0.0",
+            "babel-plugin-istanbul": "^2.0.0",
+            "babel-preset-jest": "^16.0.0"
           }
         },
         "babel-loader": {
@@ -3221,9 +3221,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loader-utils": "0.2.16",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.0"
+            "loader-utils": "^0.2.11",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.0.1"
           }
         },
         "babel-messages": {
@@ -3231,7 +3231,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.11.6"
+            "babel-runtime": "^6.0.0"
           }
         },
         "babel-plugin-istanbul": {
@@ -3239,10 +3239,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "istanbul-lib-instrument": "1.1.4",
-            "object-assign": "4.1.0",
-            "test-exclude": "2.1.3"
+            "find-up": "^1.1.2",
+            "istanbul-lib-instrument": "^1.1.4",
+            "object-assign": "^4.1.0",
+            "test-exclude": "^2.1.1"
           }
         },
         "babel-plugin-jest-hoist": {
@@ -3255,7 +3255,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "16.0.0"
+            "babel-plugin-jest-hoist": "^16.0.0"
           }
         },
         "babel-preset-react-app": {
@@ -3293,9 +3293,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "2.0.0"
+                "chalk": "^1.1.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^2.0.0"
               }
             },
             "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -3303,9 +3303,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-explode-assignable-expression": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-helper-explode-assignable-expression": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.15.0"
               }
             },
             "babel-helper-builder-react-jsx": {
@@ -3313,10 +3313,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "esutils": "2.0.2",
-                "lodash": "4.16.4"
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.9.0",
+                "esutils": "^2.0.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-helper-call-delegate": {
@@ -3324,10 +3324,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-hoist-variables": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-hoist-variables": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-traverse": "^6.8.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-define-map": {
@@ -3335,10 +3335,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-function-name": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "lodash": "4.16.4"
+                "babel-helper-function-name": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.9.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-helper-explode-assignable-expression": {
@@ -3346,9 +3346,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-traverse": "^6.8.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-function-name": {
@@ -3356,11 +3356,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-get-function-arity": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-get-function-arity": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.8.0",
+                "babel-traverse": "^6.8.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-get-function-arity": {
@@ -3368,8 +3368,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-hoist-variables": {
@@ -3377,8 +3377,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-optimise-call-expression": {
@@ -3386,8 +3386,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-helper-regex": {
@@ -3395,9 +3395,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "lodash": "4.16.4"
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.9.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-helper-remap-async-to-generator": {
@@ -3405,11 +3405,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-function-name": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-function-name": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.16.0",
+                "babel-types": "^6.16.0"
               }
             },
             "babel-helper-replace-supers": {
@@ -3417,12 +3417,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-optimise-call-expression": "6.8.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-optimise-call-expression": "^6.8.0",
+                "babel-messages": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.16.0",
+                "babel-types": "^6.16.0"
               }
             },
             "babel-messages": {
@@ -3430,7 +3430,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-check-es2015-constants": {
@@ -3438,7 +3438,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-syntax-async-functions": {
@@ -3481,9 +3481,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-remap-async-to-generator": "6.16.2",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-helper-remap-async-to-generator": "^6.16.0",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-class-properties": {
@@ -3491,9 +3491,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-function-name": "6.8.0",
-                "babel-plugin-syntax-class-properties": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-helper-function-name": "^6.8.0",
+                "babel-plugin-syntax-class-properties": "^6.8.0",
+                "babel-runtime": "^6.9.1"
               }
             },
             "babel-plugin-transform-es2015-arrow-functions": {
@@ -3501,7 +3501,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -3509,7 +3509,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-block-scoping": {
@@ -3517,11 +3517,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0",
-                "lodash": "4.16.4"
+                "babel-runtime": "^6.9.0",
+                "babel-template": "^6.15.0",
+                "babel-traverse": "^6.15.0",
+                "babel-types": "^6.15.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-plugin-transform-es2015-classes": {
@@ -3529,15 +3529,15 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-define-map": "6.9.0",
-                "babel-helper-function-name": "6.8.0",
-                "babel-helper-optimise-call-expression": "6.8.0",
-                "babel-helper-replace-supers": "6.16.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-define-map": "^6.9.0",
+                "babel-helper-function-name": "^6.8.0",
+                "babel-helper-optimise-call-expression": "^6.8.0",
+                "babel-helper-replace-supers": "^6.14.0",
+                "babel-messages": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-template": "^6.14.0",
+                "babel-traverse": "^6.14.0",
+                "babel-types": "^6.14.0"
               }
             },
             "babel-plugin-transform-es2015-computed-properties": {
@@ -3545,9 +3545,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-define-map": "6.9.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0"
+                "babel-helper-define-map": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-destructuring": {
@@ -3555,7 +3555,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.9.0"
               }
             },
             "babel-plugin-transform-es2015-duplicate-keys": {
@@ -3563,8 +3563,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-for-of": {
@@ -3572,7 +3572,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-function-name": {
@@ -3580,9 +3580,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-function-name": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-helper-function-name": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.9.0"
               }
             },
             "babel-plugin-transform-es2015-literals": {
@@ -3590,7 +3590,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-modules-amd": {
@@ -3598,9 +3598,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.16.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-modules-commonjs": {
@@ -3608,10 +3608,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-transform-strict-mode": "6.11.3",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-plugin-transform-strict-mode": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.16.0",
+                "babel-types": "^6.16.0"
               }
             },
             "babel-plugin-transform-es2015-modules-systemjs": {
@@ -3619,9 +3619,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-hoist-variables": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0"
+                "babel-helper-hoist-variables": "^6.8.0",
+                "babel-runtime": "^6.11.6",
+                "babel-template": "^6.14.0"
               }
             },
             "babel-plugin-transform-es2015-modules-umd": {
@@ -3629,9 +3629,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-template": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-object-super": {
@@ -3639,8 +3639,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-replace-supers": "6.16.0",
-                "babel-runtime": "6.11.6"
+                "babel-helper-replace-supers": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-parameters": {
@@ -3648,12 +3648,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-call-delegate": "6.8.0",
-                "babel-helper-get-function-arity": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-template": "6.16.0",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0"
+                "babel-helper-call-delegate": "^6.8.0",
+                "babel-helper-get-function-arity": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.16.0",
+                "babel-types": "^6.16.0"
               }
             },
             "babel-plugin-transform-es2015-shorthand-properties": {
@@ -3661,8 +3661,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-spread": {
@@ -3670,7 +3670,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-sticky-regex": {
@@ -3678,9 +3678,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-regex": "6.9.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-helper-regex": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-plugin-transform-es2015-template-literals": {
@@ -3688,7 +3688,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-typeof-symbol": {
@@ -3696,7 +3696,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-es2015-unicode-regex": {
@@ -3704,9 +3704,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-regex": "6.9.0",
-                "babel-runtime": "6.11.6",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.8.0",
+                "babel-runtime": "^6.0.0",
+                "regexpu-core": "^2.0.0"
               }
             },
             "babel-plugin-transform-exponentiation-operator": {
@@ -3714,9 +3714,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.15.0",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.8.0",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-flow-strip-types": {
@@ -3724,8 +3724,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-flow": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-plugin-syntax-flow": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-object-rest-spread": {
@@ -3733,8 +3733,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-react-constant-elements": {
@@ -3742,7 +3742,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.9.1"
               }
             },
             "babel-plugin-transform-react-display-name": {
@@ -3750,7 +3750,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-react-jsx": {
@@ -3758,9 +3758,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-helper-builder-react-jsx": "6.9.0",
-                "babel-plugin-syntax-jsx": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-helper-builder-react-jsx": "^6.8.0",
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-plugin-transform-react-jsx-self": {
@@ -3768,8 +3768,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-jsx": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.9.0"
               }
             },
             "babel-plugin-transform-react-jsx-source": {
@@ -3777,8 +3777,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-jsx": "6.13.0",
-                "babel-runtime": "6.11.6"
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.9.0"
               }
             },
             "babel-plugin-transform-regenerator": {
@@ -3786,9 +3786,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "private": "0.1.6"
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.16.0",
+                "private": "~0.1.5"
               }
             },
             "babel-plugin-transform-runtime": {
@@ -3796,7 +3796,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6"
+                "babel-runtime": "^6.9.0"
               }
             },
             "babel-plugin-transform-strict-mode": {
@@ -3804,8 +3804,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0"
+                "babel-runtime": "^6.0.0",
+                "babel-types": "^6.8.0"
               }
             },
             "babel-preset-env": {
@@ -3813,34 +3813,34 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-check-es2015-constants": "6.8.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.13.0",
-                "babel-plugin-transform-async-to-generator": "6.16.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.8.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.8.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.15.0",
-                "babel-plugin-transform-es2015-classes": "6.14.0",
-                "babel-plugin-transform-es2015-computed-properties": "6.8.0",
-                "babel-plugin-transform-es2015-destructuring": "6.16.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.8.0",
-                "babel-plugin-transform-es2015-for-of": "6.8.0",
-                "babel-plugin-transform-es2015-function-name": "6.9.0",
-                "babel-plugin-transform-es2015-literals": "6.8.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.8.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.16.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.14.0",
-                "babel-plugin-transform-es2015-modules-umd": "6.12.0",
-                "babel-plugin-transform-es2015-object-super": "6.8.0",
-                "babel-plugin-transform-es2015-parameters": "6.17.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.8.0",
-                "babel-plugin-transform-es2015-spread": "6.8.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.8.0",
-                "babel-plugin-transform-es2015-template-literals": "6.8.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.8.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.11.0",
-                "babel-plugin-transform-exponentiation-operator": "6.8.0",
-                "babel-plugin-transform-regenerator": "6.16.1",
-                "browserslist": "1.4.0"
+                "babel-plugin-check-es2015-constants": "^6.3.13",
+                "babel-plugin-syntax-trailing-function-commas": "^6.13.0",
+                "babel-plugin-transform-async-to-generator": "^6.8.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+                "babel-plugin-transform-es2015-block-scoping": "^6.6.0",
+                "babel-plugin-transform-es2015-classes": "^6.6.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+                "babel-plugin-transform-es2015-destructuring": "^6.6.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+                "babel-plugin-transform-es2015-for-of": "^6.6.0",
+                "babel-plugin-transform-es2015-function-name": "^6.3.13",
+                "babel-plugin-transform-es2015-literals": "^6.3.13",
+                "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.12.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.12.0",
+                "babel-plugin-transform-es2015-object-super": "^6.3.13",
+                "babel-plugin-transform-es2015-parameters": "^6.6.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+                "babel-plugin-transform-es2015-spread": "^6.3.13",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+                "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+                "babel-plugin-transform-exponentiation-operator": "^6.8.0",
+                "babel-plugin-transform-regenerator": "^6.6.0",
+                "browserslist": "^1.4.0"
               }
             },
             "babel-preset-es2015": {
@@ -3848,30 +3848,30 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-check-es2015-constants": "6.8.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.8.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.8.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.15.0",
-                "babel-plugin-transform-es2015-classes": "6.14.0",
-                "babel-plugin-transform-es2015-computed-properties": "6.8.0",
-                "babel-plugin-transform-es2015-destructuring": "6.16.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.8.0",
-                "babel-plugin-transform-es2015-for-of": "6.8.0",
-                "babel-plugin-transform-es2015-function-name": "6.9.0",
-                "babel-plugin-transform-es2015-literals": "6.8.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.8.0",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.16.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.14.0",
-                "babel-plugin-transform-es2015-modules-umd": "6.12.0",
-                "babel-plugin-transform-es2015-object-super": "6.8.0",
-                "babel-plugin-transform-es2015-parameters": "6.17.0",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.8.0",
-                "babel-plugin-transform-es2015-spread": "6.8.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.8.0",
-                "babel-plugin-transform-es2015-template-literals": "6.8.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.8.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.11.0",
-                "babel-plugin-transform-regenerator": "6.16.1"
+                "babel-plugin-check-es2015-constants": "^6.3.13",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+                "babel-plugin-transform-es2015-block-scoping": "^6.14.0",
+                "babel-plugin-transform-es2015-classes": "^6.14.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+                "babel-plugin-transform-es2015-destructuring": "^6.16.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+                "babel-plugin-transform-es2015-for-of": "^6.6.0",
+                "babel-plugin-transform-es2015-function-name": "^6.9.0",
+                "babel-plugin-transform-es2015-literals": "^6.3.13",
+                "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.16.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.14.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.12.0",
+                "babel-plugin-transform-es2015-object-super": "^6.3.13",
+                "babel-plugin-transform-es2015-parameters": "^6.16.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+                "babel-plugin-transform-es2015-spread": "^6.3.13",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+                "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+                "babel-plugin-transform-regenerator": "^6.16.0"
               }
             },
             "babel-preset-es2016": {
@@ -3879,7 +3879,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-transform-exponentiation-operator": "6.8.0"
+                "babel-plugin-transform-exponentiation-operator": "^6.3.13"
               }
             },
             "babel-preset-es2017": {
@@ -3887,8 +3887,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-trailing-function-commas": "6.13.0",
-                "babel-plugin-transform-async-to-generator": "6.16.0"
+                "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
+                "babel-plugin-transform-async-to-generator": "^6.16.0"
               }
             },
             "babel-preset-latest": {
@@ -3896,9 +3896,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-preset-es2015": "6.16.0",
-                "babel-preset-es2016": "6.16.0",
-                "babel-preset-es2017": "6.16.0"
+                "babel-preset-es2015": "^6.16.0",
+                "babel-preset-es2016": "^6.16.0",
+                "babel-preset-es2017": "^6.16.0"
               }
             },
             "babel-preset-react": {
@@ -3906,13 +3906,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-plugin-syntax-flow": "6.13.0",
-                "babel-plugin-syntax-jsx": "6.13.0",
-                "babel-plugin-transform-flow-strip-types": "6.14.0",
-                "babel-plugin-transform-react-display-name": "6.8.0",
-                "babel-plugin-transform-react-jsx": "6.8.0",
-                "babel-plugin-transform-react-jsx-self": "6.11.0",
-                "babel-plugin-transform-react-jsx-source": "6.9.0"
+                "babel-plugin-syntax-flow": "^6.3.13",
+                "babel-plugin-syntax-jsx": "^6.3.13",
+                "babel-plugin-transform-flow-strip-types": "^6.3.13",
+                "babel-plugin-transform-react-display-name": "^6.3.13",
+                "babel-plugin-transform-react-jsx": "^6.3.13",
+                "babel-plugin-transform-react-jsx-self": "^6.11.0",
+                "babel-plugin-transform-react-jsx-source": "^6.3.13"
               }
             },
             "babel-runtime": {
@@ -3920,8 +3920,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.9.5"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.9.5"
               }
             },
             "babel-template": {
@@ -3929,11 +3929,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "babel-traverse": "6.16.0",
-                "babel-types": "6.16.0",
-                "babylon": "6.13.0",
-                "lodash": "4.16.4"
+                "babel-runtime": "^6.9.0",
+                "babel-traverse": "^6.16.0",
+                "babel-types": "^6.16.0",
+                "babylon": "^6.11.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-traverse": {
@@ -3941,15 +3941,15 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-code-frame": "6.16.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.11.6",
-                "babel-types": "6.16.0",
-                "babylon": "6.13.0",
-                "debug": "2.2.0",
-                "globals": "8.18.0",
-                "invariant": "2.2.1",
-                "lodash": "4.16.4"
+                "babel-code-frame": "^6.16.0",
+                "babel-messages": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.16.0",
+                "babylon": "^6.11.0",
+                "debug": "^2.2.0",
+                "globals": "^8.3.0",
+                "invariant": "^2.2.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-types": {
@@ -3957,10 +3957,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.11.6",
-                "esutils": "2.0.2",
-                "lodash": "4.16.4",
-                "to-fast-properties": "1.0.2"
+                "babel-runtime": "^6.9.1",
+                "esutils": "^2.0.2",
+                "lodash": "^4.2.0",
+                "to-fast-properties": "^1.0.1"
               }
             },
             "babylon": {
@@ -3973,7 +3973,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "caniuse-db": "1.0.30000564"
+                "caniuse-db": "^1.0.30000539"
               }
             },
             "caniuse-db": {
@@ -3986,11 +3986,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "core-js": {
@@ -4026,7 +4026,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "invariant": {
@@ -4034,7 +4034,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "loose-envify": "1.2.0"
+                "loose-envify": "^1.0.0"
               }
             },
             "js-tokens": {
@@ -4057,7 +4057,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "js-tokens": "1.0.3"
+                "js-tokens": "^1.0.1"
               },
               "dependencies": {
                 "js-tokens": {
@@ -4092,9 +4092,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "regenerate": "1.3.1",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
               }
             },
             "regjsgen": {
@@ -4107,7 +4107,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
               }
             },
             "strip-ansi": {
@@ -4115,7 +4115,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "supports-color": {
@@ -4135,14 +4135,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-core": "6.17.0",
-            "babel-runtime": "6.11.6",
-            "core-js": "2.4.1",
-            "home-or-tmp": "1.0.0",
-            "lodash": "4.16.4",
-            "mkdirp": "0.5.1",
-            "path-exists": "1.0.0",
-            "source-map-support": "0.4.5"
+            "babel-core": "^6.16.0",
+            "babel-runtime": "^6.11.6",
+            "core-js": "^2.4.0",
+            "home-or-tmp": "^1.0.0",
+            "lodash": "^4.2.0",
+            "mkdirp": "^0.5.1",
+            "path-exists": "^1.0.0",
+            "source-map-support": "^0.4.2"
           },
           "dependencies": {
             "path-exists": {
@@ -4157,8 +4157,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.9.5"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.9.5"
           }
         },
         "babel-template": {
@@ -4166,11 +4166,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.11.6",
-            "babel-traverse": "6.16.0",
-            "babel-types": "6.16.0",
-            "babylon": "6.13.0",
-            "lodash": "4.16.4"
+            "babel-runtime": "^6.9.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-traverse": {
@@ -4178,15 +4178,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.16.0",
-            "babel-messages": "6.8.0",
-            "babel-runtime": "6.11.6",
-            "babel-types": "6.16.0",
-            "babylon": "6.13.0",
-            "debug": "2.2.0",
-            "globals": "8.18.0",
-            "invariant": "2.2.1",
-            "lodash": "4.16.4"
+            "babel-code-frame": "^6.16.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "debug": "^2.2.0",
+            "globals": "^8.3.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-types": {
@@ -4194,10 +4194,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.11.6",
-            "esutils": "2.0.2",
-            "lodash": "4.16.4",
-            "to-fast-properties": "1.0.2"
+            "babel-runtime": "^6.9.1",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
           }
         },
         "babylon": {
@@ -4226,7 +4226,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.3"
+            "tweetnacl": "^0.14.3"
           }
         },
         "big.js": {
@@ -4244,7 +4244,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "readable-stream": "2.0.6"
+            "readable-stream": "~2.0.5"
           }
         },
         "bluebird": {
@@ -4262,7 +4262,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -4270,7 +4270,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -4279,9 +4279,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "browser-resolve": {
@@ -4297,7 +4297,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "browserslist": {
@@ -4305,7 +4305,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000564"
+            "caniuse-db": "^1.0.30000539"
           }
         },
         "bser": {
@@ -4313,7 +4313,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "node-int64": "0.4.0"
+            "node-int64": "^0.4.0"
           }
         },
         "buffer": {
@@ -4321,9 +4321,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "base64-js": "1.2.0",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "builtin-modules": {
@@ -4341,7 +4341,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "callsites": "0.2.0"
+            "callsites": "^0.2.0"
           }
         },
         "callsites": {
@@ -4354,8 +4354,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0",
-            "upper-case": "1.1.3"
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
           }
         },
         "camelcase": {
@@ -4373,8 +4373,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansicolors": "0.2.1",
-            "redeyed": "1.0.0"
+            "ansicolors": "~0.2.1",
+            "redeyed": "~1.0.0"
           }
         },
         "case-sensitive-paths-webpack-plugin": {
@@ -4392,8 +4392,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -4401,11 +4401,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -4420,24 +4420,24 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camel-case": "3.0.0",
-            "constant-case": "2.0.0",
-            "dot-case": "2.1.0",
-            "header-case": "1.0.0",
-            "is-lower-case": "1.1.3",
-            "is-upper-case": "1.1.2",
-            "lower-case": "1.1.3",
-            "lower-case-first": "1.0.2",
-            "no-case": "2.3.0",
-            "param-case": "2.1.0",
-            "pascal-case": "2.0.0",
-            "path-case": "2.1.0",
-            "sentence-case": "2.1.0",
-            "snake-case": "2.1.0",
-            "swap-case": "1.1.2",
-            "title-case": "2.1.0",
-            "upper-case": "1.1.3",
-            "upper-case-first": "1.1.2"
+            "camel-case": "^3.0.0",
+            "constant-case": "^2.0.0",
+            "dot-case": "^2.1.0",
+            "header-case": "^1.0.0",
+            "is-lower-case": "^1.1.0",
+            "is-upper-case": "^1.1.0",
+            "lower-case": "^1.1.1",
+            "lower-case-first": "^1.0.0",
+            "no-case": "^2.2.0",
+            "param-case": "^2.1.0",
+            "pascal-case": "^2.0.0",
+            "path-case": "^2.1.0",
+            "sentence-case": "^2.1.0",
+            "snake-case": "^2.1.0",
+            "swap-case": "^1.1.0",
+            "title-case": "^2.1.0",
+            "upper-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
           }
         },
         "chokidar": {
@@ -4445,15 +4445,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "anymatch": "1.3.0",
-            "async-each": "1.0.1",
-            "fsevents": "1.0.14",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           },
           "dependencies": {
             "fsevents": {
@@ -4462,8 +4462,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "nan": "2.4.0",
-                "node-pre-gyp": "0.6.29"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.29"
               },
               "dependencies": {
                 "abbrev": {
@@ -4495,8 +4495,8 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.4"
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.0 || ^1.1.13"
                   }
                 },
                 "asn1": {
@@ -4540,7 +4540,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "readable-stream": "2.0.6"
+                    "readable-stream": "~2.0.5"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -4549,12 +4549,12 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.1",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       }
                     }
                   }
@@ -4564,7 +4564,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.1"
+                    "inherits": "~2.0.0"
                   }
                 },
                 "boom": {
@@ -4572,7 +4572,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 },
                 "brace-expansion": {
@@ -4580,7 +4580,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   }
                 },
@@ -4601,11 +4601,11 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   }
                 },
                 "code-point-at": {
@@ -4613,7 +4613,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.0"
+                    "number-is-nan": "^1.0.0"
                   }
                 },
                 "combined-stream": {
@@ -4621,7 +4621,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   }
                 },
                 "commander": {
@@ -4630,7 +4630,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "graceful-readlink": "1.0.1"
+                    "graceful-readlink": ">= 1.0.0"
                   }
                 },
                 "concat-map": {
@@ -4654,7 +4654,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "boom": "2.10.1"
+                    "boom": "2.x.x"
                   }
                 },
                 "dashdash": {
@@ -4663,7 +4663,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "assert-plus": "1.0.0"
+                    "assert-plus": "^1.0.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -4706,7 +4706,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "jsbn": "0.1.0"
+                    "jsbn": "~0.1.0"
                   }
                 },
                 "escape-string-regexp": {
@@ -4738,9 +4738,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "async": "1.5.2",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.11"
+                    "async": "^1.5.2",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.10"
                   }
                 },
                 "fs.realpath": {
@@ -4753,10 +4753,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "4.1.4",
-                    "inherits": "2.0.1",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.3"
+                    "graceful-fs": "^4.1.2",
+                    "inherits": "~2.0.0",
+                    "mkdirp": ">=0.5 0",
+                    "rimraf": "2"
                   }
                 },
                 "fstream-ignore": {
@@ -4765,9 +4765,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "fstream": "1.0.10",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.2"
+                    "fstream": "^1.0.0",
+                    "inherits": "2",
+                    "minimatch": "^3.0.0"
                   }
                 },
                 "gauge": {
@@ -4776,15 +4776,15 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "aproba": "1.0.4",
-                    "console-control-strings": "1.1.0",
-                    "has-color": "0.1.7",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.0",
-                    "signal-exit": "3.0.0",
-                    "string-width": "1.0.1",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.0"
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-color": "^0.1.7",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wide-align": "^1.1.0"
                   }
                 },
                 "generate-function": {
@@ -4799,7 +4799,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "is-property": "1.0.2"
+                    "is-property": "^1.0.0"
                   }
                 },
                 "getpass": {
@@ -4808,7 +4808,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "assert-plus": "1.0.0"
+                    "assert-plus": "^1.0.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -4824,12 +4824,12 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.5",
-                    "inherits": "2.0.1",
-                    "minimatch": "3.0.2",
-                    "once": "1.3.3",
-                    "path-is-absolute": "1.0.0"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   }
                 },
                 "graceful-fs": {
@@ -4849,10 +4849,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "chalk": "1.1.3",
-                    "commander": "2.9.0",
-                    "is-my-json-valid": "2.13.1",
-                    "pinkie-promise": "2.0.1"
+                    "chalk": "^1.1.1",
+                    "commander": "^2.9.0",
+                    "is-my-json-valid": "^2.12.4",
+                    "pinkie-promise": "^2.0.0"
                   }
                 },
                 "has-ansi": {
@@ -4861,7 +4861,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   }
                 },
                 "has-color": {
@@ -4882,10 +4882,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
                   }
                 },
                 "hoek": {
@@ -4899,9 +4899,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.3.0",
-                    "sshpk": "1.8.3"
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
                   }
                 },
                 "inflight": {
@@ -4909,8 +4909,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "once": "1.3.3",
-                    "wrappy": "1.0.2"
+                    "once": "^1.3.0",
+                    "wrappy": "1"
                   }
                 },
                 "inherits": {
@@ -4929,7 +4929,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "1.0.0"
+                    "number-is-nan": "^1.0.0"
                   }
                 },
                 "is-my-json-valid": {
@@ -4938,10 +4938,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
+                    "generate-function": "^2.0.0",
+                    "generate-object-property": "^1.1.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "4.0.1"
+                    "xtend": "^4.0.0"
                   }
                 },
                 "is-property": {
@@ -4973,7 +4973,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "jsbn": "0.1.0"
+                    "jsbn": "~0.1.0"
                   }
                 },
                 "jsbn": {
@@ -5021,7 +5021,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.23.0"
+                    "mime-db": "~1.23.0"
                   }
                 },
                 "minimatch": {
@@ -5029,7 +5029,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.5"
+                    "brace-expansion": "^1.0.0"
                   }
                 },
                 "minimist": {
@@ -5057,15 +5057,15 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "mkdirp": "0.5.1",
-                    "nopt": "3.0.6",
-                    "npmlog": "3.1.2",
-                    "rc": "1.1.6",
-                    "request": "2.73.0",
-                    "rimraf": "2.5.3",
-                    "semver": "5.2.0",
-                    "tar": "2.2.1",
-                    "tar-pack": "3.1.4"
+                    "mkdirp": "~0.5.0",
+                    "nopt": "~3.0.1",
+                    "npmlog": "~3.1.2",
+                    "rc": "~1.1.0",
+                    "request": "2.x",
+                    "rimraf": "~2.5.0",
+                    "semver": "~5.2.0",
+                    "tar": "~2.2.0",
+                    "tar-pack": "~3.1.0"
                   }
                 },
                 "node-uuid": {
@@ -5080,7 +5080,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "abbrev": "1.0.9"
+                    "abbrev": "1"
                   }
                 },
                 "npmlog": {
@@ -5089,10 +5089,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "are-we-there-yet": "1.1.2",
-                    "console-control-strings": "1.1.0",
-                    "gauge": "2.6.0",
-                    "set-blocking": "2.0.0"
+                    "are-we-there-yet": "~1.1.2",
+                    "console-control-strings": "~1.1.0",
+                    "gauge": "~2.6.0",
+                    "set-blocking": "~2.0.0"
                   }
                 },
                 "number-is-nan": {
@@ -5117,7 +5117,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "wrappy": "1.0.2"
+                    "wrappy": "1"
                   }
                 },
                 "path-is-absolute": {
@@ -5137,7 +5137,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "pinkie": "2.0.4"
+                    "pinkie": "^2.0.0"
                   }
                 },
                 "process-nextick-args": {
@@ -5157,10 +5157,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "deep-extend": "0.4.1",
-                    "ini": "1.3.4",
-                    "minimist": "1.2.0",
-                    "strip-json-comments": "1.0.4"
+                    "deep-extend": "~0.4.0",
+                    "ini": "~1.3.0",
+                    "minimist": "^1.2.0",
+                    "strip-json-comments": "~1.0.4"
                   },
                   "dependencies": {
                     "minimist": {
@@ -5176,13 +5176,13 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "buffer-shims": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.1",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
+                    "buffer-shims": "^1.0.0",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~1.0.6",
+                    "string_decoder": "~0.10.x",
+                    "util-deprecate": "~1.0.1"
                   }
                 },
                 "request": {
@@ -5191,27 +5191,27 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "aws-sign2": "0.6.0",
-                    "aws4": "1.4.1",
-                    "bl": "1.1.2",
-                    "caseless": "0.11.0",
-                    "combined-stream": "1.0.5",
-                    "extend": "3.0.0",
-                    "forever-agent": "0.6.1",
-                    "form-data": "1.0.0-rc4",
-                    "har-validator": "2.0.6",
-                    "hawk": "3.1.3",
-                    "http-signature": "1.1.1",
-                    "is-typedarray": "1.0.0",
-                    "isstream": "0.1.2",
-                    "json-stringify-safe": "5.0.1",
-                    "mime-types": "2.1.11",
-                    "node-uuid": "1.4.7",
-                    "oauth-sign": "0.8.2",
-                    "qs": "6.2.0",
-                    "stringstream": "0.0.5",
-                    "tough-cookie": "2.2.2",
-                    "tunnel-agent": "0.4.3"
+                    "aws-sign2": "~0.6.0",
+                    "aws4": "^1.2.1",
+                    "bl": "~1.1.2",
+                    "caseless": "~0.11.0",
+                    "combined-stream": "~1.0.5",
+                    "extend": "~3.0.0",
+                    "forever-agent": "~0.6.1",
+                    "form-data": "~1.0.0-rc4",
+                    "har-validator": "~2.0.6",
+                    "hawk": "~3.1.3",
+                    "http-signature": "~1.1.0",
+                    "is-typedarray": "~1.0.0",
+                    "isstream": "~0.1.2",
+                    "json-stringify-safe": "~5.0.1",
+                    "mime-types": "~2.1.7",
+                    "node-uuid": "~1.4.7",
+                    "oauth-sign": "~0.8.1",
+                    "qs": "~6.2.0",
+                    "stringstream": "~0.0.4",
+                    "tough-cookie": "~2.2.0",
+                    "tunnel-agent": "~0.4.1"
                   }
                 },
                 "rimraf": {
@@ -5219,7 +5219,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "glob": "7.0.5"
+                    "glob": "^7.0.5"
                   }
                 },
                 "semver": {
@@ -5246,7 +5246,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 },
                 "sshpk": {
@@ -5255,14 +5255,14 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "dashdash": "1.14.0",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.6",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.0",
-                    "tweetnacl": "0.13.3"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jodid25519": "^1.0.0",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.13.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -5278,9 +5278,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.0.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 },
                 "string_decoder": {
@@ -5299,7 +5299,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.0.0"
+                    "ansi-regex": "^2.0.0"
                   }
                 },
                 "strip-json-comments": {
@@ -5319,9 +5319,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "block-stream": "0.0.9",
-                    "fstream": "1.0.10",
-                    "inherits": "2.0.1"
+                    "block-stream": "*",
+                    "fstream": "^1.0.2",
+                    "inherits": "2"
                   }
                 },
                 "tar-pack": {
@@ -5330,14 +5330,14 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "debug": "2.2.0",
-                    "fstream": "1.0.10",
-                    "fstream-ignore": "1.0.5",
-                    "once": "1.3.3",
-                    "readable-stream": "2.1.4",
-                    "rimraf": "2.5.3",
-                    "tar": "2.2.1",
-                    "uid-number": "0.0.6"
+                    "debug": "~2.2.0",
+                    "fstream": "~1.0.10",
+                    "fstream-ignore": "~1.0.5",
+                    "once": "~1.3.3",
+                    "readable-stream": "~2.1.4",
+                    "rimraf": "~2.5.1",
+                    "tar": "~2.2.1",
+                    "uid-number": "~0.0.6"
                   }
                 },
                 "tough-cookie": {
@@ -5384,7 +5384,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "string-width": "1.0.1"
+                    "string-width": "^1.0.1"
                   }
                 },
                 "wrappy": {
@@ -5417,7 +5417,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.1.3"
           }
         },
         "clean-css": {
@@ -5425,8 +5425,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commander": "2.8.1",
-            "source-map": "0.4.4"
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
           },
           "dependencies": {
             "source-map": {
@@ -5434,7 +5434,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.0"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -5444,7 +5444,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "cli-table": {
@@ -5467,8 +5467,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "marked": "0.3.6",
-            "marked-terminal": "1.6.2"
+            "marked": "^0.3.6",
+            "marked-terminal": "^1.6.2"
           }
         },
         "cli-width": {
@@ -5481,8 +5481,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -5508,7 +5508,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "q": "1.4.1"
+            "q": "^1.1.2"
           }
         },
         "code-point-at": {
@@ -5516,7 +5516,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "color": {
@@ -5524,9 +5524,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "color-convert": "1.5.0",
-            "color-string": "0.3.0"
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
           }
         },
         "color-convert": {
@@ -5544,7 +5544,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "1.1.1"
+            "color-name": "^1.0.0"
           }
         },
         "colormin": {
@@ -5552,9 +5552,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color": "0.11.3",
+            "color": "^0.11.0",
             "css-color-names": "0.0.4",
-            "has": "1.0.1"
+            "has": "^1.0.1"
           }
         },
         "colors": {
@@ -5567,7 +5567,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -5575,7 +5575,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "commondir": {
@@ -5588,7 +5588,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.24.0"
+            "mime-db": ">= 1.23.0 < 2"
           }
         },
         "compression": {
@@ -5596,12 +5596,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
+            "accepts": "~1.3.3",
             "bytes": "2.3.0",
-            "compressible": "2.0.8",
-            "debug": "2.2.0",
-            "on-headers": "1.0.1",
-            "vary": "1.1.0"
+            "compressible": "~2.0.8",
+            "debug": "~2.2.0",
+            "on-headers": "~1.0.1",
+            "vary": "~1.1.0"
           }
         },
         "concat-map": {
@@ -5614,9 +5614,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           }
         },
         "connect-history-api-fallback": {
@@ -5629,7 +5629,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "constant-case": {
@@ -5637,8 +5637,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "snake-case": "2.1.0",
-            "upper-case": "1.1.3"
+            "snake-case": "^2.1.0",
+            "upper-case": "^1.1.1"
           }
         },
         "constants-browserify": {
@@ -5696,13 +5696,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "js-yaml": "3.6.1",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.0",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "require-from-string": "1.2.1"
+            "graceful-fs": "^4.1.2",
+            "js-yaml": "^3.4.3",
+            "minimist": "^1.2.0",
+            "object-assign": "^4.1.0",
+            "os-homedir": "^1.0.1",
+            "parse-json": "^2.2.0",
+            "require-from-string": "^1.1.0"
           }
         },
         "cross-spawn": {
@@ -5710,8 +5710,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.0.1",
-            "which": "1.2.11"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "cryptiles": {
@@ -5719,7 +5719,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "crypto-browserify": {
@@ -5742,18 +5742,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.16.0",
-            "css-selector-tokenizer": "0.6.0",
-            "cssnano": "3.7.7",
-            "loader-utils": "0.2.16",
-            "lodash.camelcase": "3.0.1",
-            "object-assign": "4.1.0",
-            "postcss": "5.2.5",
-            "postcss-modules-extract-imports": "1.0.1",
-            "postcss-modules-local-by-default": "1.1.1",
-            "postcss-modules-scope": "1.0.2",
-            "postcss-modules-values": "1.2.2",
-            "source-list-map": "0.1.6"
+            "babel-code-frame": "^6.11.0",
+            "css-selector-tokenizer": "^0.6.0",
+            "cssnano": ">=2.6.1 <4",
+            "loader-utils": "~0.2.2",
+            "lodash.camelcase": "^3.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.6",
+            "postcss-modules-extract-imports": "^1.0.0",
+            "postcss-modules-local-by-default": "^1.0.1",
+            "postcss-modules-scope": "^1.0.0",
+            "postcss-modules-values": "^1.1.0",
+            "source-list-map": "^0.1.4"
           }
         },
         "css-select": {
@@ -5761,10 +5761,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boolbase": "1.0.0",
-            "css-what": "2.1.0",
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
             "domutils": "1.5.1",
-            "nth-check": "1.0.1"
+            "nth-check": "~1.0.1"
           }
         },
         "css-selector-tokenizer": {
@@ -5772,9 +5772,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cssesc": "0.1.0",
-            "fastparse": "1.1.1",
-            "regexpu-core": "1.0.0"
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1",
+            "regexpu-core": "^1.0.0"
           }
         },
         "css-what": {
@@ -5792,38 +5792,38 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "autoprefixer": "6.5.1",
-            "decamelize": "1.2.0",
-            "defined": "1.0.0",
-            "has": "1.0.1",
-            "object-assign": "4.1.0",
-            "postcss": "5.2.5",
-            "postcss-calc": "5.3.1",
-            "postcss-colormin": "2.2.1",
-            "postcss-convert-values": "2.4.1",
-            "postcss-discard-comments": "2.0.4",
-            "postcss-discard-duplicates": "2.0.1",
-            "postcss-discard-empty": "2.1.0",
-            "postcss-discard-overridden": "0.1.1",
-            "postcss-discard-unused": "2.2.2",
-            "postcss-filter-plugins": "2.0.2",
-            "postcss-merge-idents": "2.1.7",
-            "postcss-merge-longhand": "2.0.1",
-            "postcss-merge-rules": "2.0.10",
-            "postcss-minify-font-values": "1.0.5",
-            "postcss-minify-gradients": "1.0.4",
-            "postcss-minify-params": "1.0.5",
-            "postcss-minify-selectors": "2.0.5",
-            "postcss-normalize-charset": "1.1.0",
-            "postcss-normalize-url": "3.0.7",
-            "postcss-ordered-values": "2.2.2",
-            "postcss-reduce-idents": "2.3.1",
-            "postcss-reduce-initial": "1.0.0",
-            "postcss-reduce-transforms": "1.0.3",
-            "postcss-svgo": "2.1.5",
-            "postcss-unique-selectors": "2.0.2",
-            "postcss-value-parser": "3.3.0",
-            "postcss-zindex": "2.1.1"
+            "autoprefixer": "^6.3.1",
+            "decamelize": "^1.1.2",
+            "defined": "^1.0.0",
+            "has": "^1.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.14",
+            "postcss-calc": "^5.2.0",
+            "postcss-colormin": "^2.1.8",
+            "postcss-convert-values": "^2.3.4",
+            "postcss-discard-comments": "^2.0.4",
+            "postcss-discard-duplicates": "^2.0.1",
+            "postcss-discard-empty": "^2.0.1",
+            "postcss-discard-overridden": "^0.1.1",
+            "postcss-discard-unused": "^2.2.1",
+            "postcss-filter-plugins": "^2.0.0",
+            "postcss-merge-idents": "^2.1.5",
+            "postcss-merge-longhand": "^2.0.1",
+            "postcss-merge-rules": "^2.0.3",
+            "postcss-minify-font-values": "^1.0.2",
+            "postcss-minify-gradients": "^1.0.1",
+            "postcss-minify-params": "^1.0.4",
+            "postcss-minify-selectors": "^2.0.4",
+            "postcss-normalize-charset": "^1.1.0",
+            "postcss-normalize-url": "^3.0.7",
+            "postcss-ordered-values": "^2.1.0",
+            "postcss-reduce-idents": "^2.2.2",
+            "postcss-reduce-initial": "^1.0.0",
+            "postcss-reduce-transforms": "^1.0.3",
+            "postcss-svgo": "^2.1.1",
+            "postcss-unique-selectors": "^2.0.2",
+            "postcss-value-parser": "^3.2.3",
+            "postcss-zindex": "^2.0.1"
           }
         },
         "csso": {
@@ -5831,8 +5831,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "clap": "1.1.1",
-            "source-map": "0.5.6"
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
           }
         },
         "cssom": {
@@ -5845,7 +5845,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cssom": "0.3.1"
+            "cssom": "0.3.x"
           }
         },
         "d": {
@@ -5853,7 +5853,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.12"
+            "es5-ext": "~0.10.2"
           }
         },
         "damerau-levenshtein": {
@@ -5866,7 +5866,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5909,13 +5909,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.5.4"
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "delayed-stream": {
@@ -5938,9 +5938,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
           }
         },
         "detect-port": {
@@ -5948,7 +5948,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commander": "2.8.1"
+            "commander": "~2.8.1"
           }
         },
         "diff": {
@@ -5961,8 +5961,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "dom-converter": {
@@ -5970,7 +5970,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "utila": "0.3.3"
+            "utila": "~0.3"
           },
           "dependencies": {
             "utila": {
@@ -5985,8 +5985,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "domelementtype": "1.1.3",
-            "entities": "1.1.1"
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
           },
           "dependencies": {
             "domelementtype": {
@@ -6011,7 +6011,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "domutils": {
@@ -6019,8 +6019,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "dot-case": {
@@ -6028,7 +6028,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0"
+            "no-case": "^2.2.0"
           }
         },
         "dotenv": {
@@ -6047,7 +6047,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.0"
+            "jsbn": "~0.1.0"
           }
         },
         "ee-first": {
@@ -6070,9 +6070,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "memory-fs": "0.2.0",
-            "tapable": "0.1.10"
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
           },
           "dependencies": {
             "memory-fs": {
@@ -6092,7 +6092,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prr": "0.0.0"
+            "prr": "~0.0.0"
           }
         },
         "error-ex": {
@@ -6100,7 +6100,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "es5-ext": {
@@ -6108,8 +6108,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-iterator": "2.0.0",
-            "es6-symbol": "3.1.0"
+            "es6-iterator": "2",
+            "es6-symbol": "~3.1"
           }
         },
         "es6-iterator": {
@@ -6117,9 +6117,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12",
-            "es6-symbol": "3.1.0"
+            "d": "^0.1.1",
+            "es5-ext": "^0.10.7",
+            "es6-symbol": "3"
           }
         },
         "es6-map": {
@@ -6127,12 +6127,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12",
-            "es6-iterator": "2.0.0",
-            "es6-set": "0.1.4",
-            "es6-symbol": "3.1.0",
-            "event-emitter": "0.3.4"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11",
+            "es6-iterator": "2",
+            "es6-set": "~0.1.3",
+            "es6-symbol": "~3.1.0",
+            "event-emitter": "~0.3.4"
           }
         },
         "es6-set": {
@@ -6140,11 +6140,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12",
-            "es6-iterator": "2.0.0",
-            "es6-symbol": "3.1.0",
-            "event-emitter": "0.3.4"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11",
+            "es6-iterator": "2",
+            "es6-symbol": "3",
+            "event-emitter": "~0.3.4"
           }
         },
         "es6-symbol": {
@@ -6152,8 +6152,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.11"
           }
         },
         "es6-weak-map": {
@@ -6161,10 +6161,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12",
-            "es6-iterator": "2.0.0",
-            "es6-symbol": "3.1.0"
+            "d": "^0.1.1",
+            "es5-ext": "^0.10.8",
+            "es6-iterator": "2",
+            "es6-symbol": "3"
           }
         },
         "escape-html": {
@@ -6182,11 +6182,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
           },
           "dependencies": {
             "estraverse": {
@@ -6200,7 +6200,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "amdefine": "1.0.0"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -6210,10 +6210,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "es6-map": "0.1.4",
-            "es6-weak-map": "2.0.1",
-            "esrecurse": "4.1.0",
-            "estraverse": "4.2.0"
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "eslint": {
@@ -6221,39 +6221,39 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.5.2",
-            "debug": "2.2.0",
-            "doctrine": "1.5.0",
-            "escope": "3.6.0",
-            "espree": "3.3.2",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "glob": "7.1.1",
-            "globals": "9.12.0",
-            "ignore": "3.2.0",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.15.0",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.6.1",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.16.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.2",
-            "shelljs": "0.6.1",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.4.6",
+            "debug": "^2.1.1",
+            "doctrine": "^1.2.2",
+            "escope": "^3.6.0",
+            "espree": "^3.3.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "glob": "^7.0.3",
+            "globals": "^9.2.0",
+            "ignore": "^3.1.5",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.6.0",
+            "strip-bom": "^3.0.0",
+            "strip-json-comments": "~1.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
           },
           "dependencies": {
             "globals": {
@@ -6271,7 +6271,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
               }
             }
           }
@@ -6286,9 +6286,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
-            "object-assign": "4.1.0",
-            "resolve": "1.1.7"
+            "debug": "^2.2.0",
+            "object-assign": "^4.0.1",
+            "resolve": "^1.1.6"
           }
         },
         "eslint-loader": {
@@ -6296,9 +6296,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-cache-dir": "0.1.1",
-            "loader-utils": "0.2.16",
-            "object-assign": "4.1.0"
+            "find-cache-dir": "^0.1.1",
+            "loader-utils": "^0.2.7",
+            "object-assign": "^4.0.1"
           }
         },
         "eslint-module-utils": {
@@ -6307,7 +6307,7 @@
           "dev": true,
           "requires": {
             "debug": "2.2.0",
-            "pkg-dir": "1.0.0"
+            "pkg-dir": "^1.0.0"
           }
         },
         "eslint-plugin-flowtype": {
@@ -6315,7 +6315,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash": "4.16.4"
+            "lodash": "^4.15.0"
           }
         },
         "eslint-plugin-import": {
@@ -6323,16 +6323,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1",
-            "contains-path": "0.1.0",
-            "debug": "2.2.0",
-            "doctrine": "1.3.0",
-            "eslint-import-resolver-node": "0.2.3",
-            "eslint-module-utils": "1.0.0",
-            "has": "1.0.1",
-            "lodash.cond": "4.5.2",
-            "minimatch": "3.0.3",
-            "pkg-up": "1.0.0"
+            "builtin-modules": "^1.1.1",
+            "contains-path": "^0.1.0",
+            "debug": "^2.2.0",
+            "doctrine": "1.3.x",
+            "eslint-import-resolver-node": "^0.2.0",
+            "eslint-module-utils": "^1.0.0",
+            "has": "^1.0.1",
+            "lodash.cond": "^4.3.0",
+            "minimatch": "^3.0.3",
+            "pkg-up": "^1.0.0"
           },
           "dependencies": {
             "doctrine": {
@@ -6340,8 +6340,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
               }
             }
           }
@@ -6351,9 +6351,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "damerau-levenshtein": "1.0.3",
-            "jsx-ast-utils": "1.3.2",
-            "object-assign": "4.1.0"
+            "damerau-levenshtein": "^1.0.0",
+            "jsx-ast-utils": "^1.0.0",
+            "object-assign": "^4.0.1"
           }
         },
         "eslint-plugin-react": {
@@ -6361,8 +6361,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "doctrine": "1.5.0",
-            "jsx-ast-utils": "1.3.2"
+            "doctrine": "^1.2.2",
+            "jsx-ast-utils": "^1.3.1"
           }
         },
         "espree": {
@@ -6370,8 +6370,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "acorn": "4.0.3",
-            "acorn-jsx": "3.0.1"
+            "acorn": "^4.0.1",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "esprima": {
@@ -6384,8 +6384,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "estraverse": "4.1.1",
-            "object-assign": "4.1.0"
+            "estraverse": "~4.1.0",
+            "object-assign": "^4.0.1"
           },
           "dependencies": {
             "estraverse": {
@@ -6415,8 +6415,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.12"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.7"
           }
         },
         "eventemitter3": {
@@ -6434,7 +6434,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "original": "1.0.0"
+            "original": ">=0.0.5"
           }
         },
         "exec-sh": {
@@ -6442,7 +6442,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "merge": "1.2.0"
+            "merge": "^1.1.3"
           }
         },
         "exit-hook": {
@@ -6455,7 +6455,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -6463,7 +6463,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "express": {
@@ -6471,32 +6471,32 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
+            "accepts": "~1.3.3",
             "array-flatten": "1.1.1",
             "content-disposition": "0.5.1",
-            "content-type": "1.0.2",
+            "content-type": "~1.0.2",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
-            "debug": "2.2.0",
-            "depd": "1.1.0",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "finalhandler": "0.5.0",
             "fresh": "0.3.0",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "1.1.2",
+            "proxy-addr": "~1.1.2",
             "qs": "6.2.0",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "send": "0.14.1",
-            "serve-static": "1.11.1",
-            "type-is": "1.6.13",
+            "serve-static": "~1.11.1",
+            "type-is": "~1.6.13",
             "utils-merge": "1.0.0",
-            "vary": "1.1.0"
+            "vary": "~1.1.0"
           },
           "dependencies": {
             "qs": {
@@ -6516,7 +6516,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "extract-text-webpack-plugin": {
@@ -6524,9 +6524,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "loader-utils": "0.2.16",
-            "webpack-sources": "0.1.2"
+            "async": "^1.5.0",
+            "loader-utils": "^0.2.3",
+            "webpack-sources": "^0.1.0"
           }
         },
         "extsprintf": {
@@ -6549,7 +6549,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "websocket-driver": "0.6.5"
+            "websocket-driver": ">=0.5.1"
           }
         },
         "fb-watchman": {
@@ -6557,7 +6557,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bser": "1.0.2"
+            "bser": "^1.0.2"
           }
         },
         "figures": {
@@ -6565,8 +6565,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.0"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "file-entry-cache": {
@@ -6574,8 +6574,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "flat-cache": "1.2.1",
-            "object-assign": "4.1.0"
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
           }
         },
         "file-loader": {
@@ -6583,7 +6583,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loader-utils": "0.2.16"
+            "loader-utils": "~0.2.5"
           }
         },
         "filename-regex": {
@@ -6596,8 +6596,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "minimatch": "2.0.10"
+            "glob": "5.x",
+            "minimatch": "2.x"
           },
           "dependencies": {
             "glob": {
@@ -6605,11 +6605,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "minimatch": {
@@ -6617,7 +6617,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               }
             }
           }
@@ -6632,11 +6632,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.5",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.5.4"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "finalhandler": {
@@ -6644,11 +6644,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "statuses": "1.3.0",
-            "unpipe": "1.0.0"
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "statuses": "~1.3.0",
+            "unpipe": "~1.0.0"
           }
         },
         "find-cache-dir": {
@@ -6656,9 +6656,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -6666,8 +6666,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "flat-cache": {
@@ -6675,10 +6675,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "circular-json": "0.3.1",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.9",
-            "write": "0.2.1"
+            "circular-json": "^0.3.0",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
           }
         },
         "flatten": {
@@ -6696,7 +6696,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "0.1.6"
+            "for-in": "^0.1.5"
           }
         },
         "forever-agent": {
@@ -6709,9 +6709,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.12"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "forwarded": {
@@ -6729,11 +6729,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.5.4"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "fs.realpath": {
@@ -6756,7 +6756,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-property": "1.0.2"
+            "is-property": "^1.0.0"
           }
         },
         "get-caller-file": {
@@ -6774,7 +6774,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6789,12 +6789,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -6802,8 +6802,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -6811,7 +6811,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -6824,12 +6824,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.1",
-            "object-assign": "4.1.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "graceful-fs": {
@@ -6852,7 +6852,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "duplexer": "0.1.1"
+            "duplexer": "^0.1.1"
           }
         },
         "handlebars": {
@@ -6860,10 +6860,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.7.3"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -6871,7 +6871,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.0"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -6881,10 +6881,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.15.0",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "commander": {
@@ -6892,7 +6892,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
               }
             }
           }
@@ -6902,7 +6902,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "function-bind": "1.1.0"
+            "function-bind": "^1.0.2"
           }
         },
         "has-ansi": {
@@ -6910,7 +6910,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -6923,10 +6923,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "he": {
@@ -6939,8 +6939,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0",
-            "upper-case": "1.1.3"
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.3"
           }
         },
         "hoek": {
@@ -6953,8 +6953,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
           }
         },
         "hosted-git-info": {
@@ -6972,7 +6972,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "whatwg-encoding": "1.0.1"
+            "whatwg-encoding": "^1.0.1"
           }
         },
         "html-minifier": {
@@ -6980,13 +6980,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "change-case": "3.0.0",
-            "clean-css": "3.4.20",
-            "commander": "2.9.0",
-            "he": "1.1.0",
-            "ncname": "1.0.0",
-            "relateurl": "0.2.7",
-            "uglify-js": "2.7.3"
+            "change-case": "3.0.x",
+            "clean-css": "3.4.x",
+            "commander": "2.9.x",
+            "he": "1.1.x",
+            "ncname": "1.0.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "2.7.x"
           },
           "dependencies": {
             "commander": {
@@ -6994,7 +6994,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
               }
             }
           }
@@ -7004,12 +7004,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "bluebird": "3.4.6",
-            "html-minifier": "3.1.0",
-            "loader-utils": "0.2.16",
-            "lodash": "4.16.4",
-            "pretty-error": "2.0.2",
-            "toposort": "1.0.0"
+            "bluebird": "^3.4.6",
+            "html-minifier": "^3.1.0",
+            "loader-utils": "^0.2.16",
+            "lodash": "^4.16.4",
+            "pretty-error": "^2.0.2",
+            "toposort": "^1.0.0"
           }
         },
         "htmlparser2": {
@@ -7017,10 +7017,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
           },
           "dependencies": {
             "domutils": {
@@ -7028,7 +7028,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
               }
             },
             "isarray": {
@@ -7041,10 +7041,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             }
           }
@@ -7054,8 +7054,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "Base64": "0.2.1",
-            "inherits": "2.0.3"
+            "Base64": "~0.2.0",
+            "inherits": "~2.0.1"
           }
         },
         "http-errors": {
@@ -7065,7 +7065,7 @@
           "requires": {
             "inherits": "2.0.1",
             "setprototypeof": "1.0.1",
-            "statuses": "1.3.0"
+            "statuses": ">= 1.3.0 < 2"
           },
           "dependencies": {
             "inherits": {
@@ -7080,8 +7080,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "eventemitter3": "1.2.0",
-            "requires-port": "1.0.0"
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
           }
         },
         "http-proxy-middleware": {
@@ -7089,10 +7089,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "http-proxy": "1.15.2",
-            "is-glob": "3.1.0",
-            "lodash": "4.16.4",
-            "micromatch": "2.3.11"
+            "http-proxy": "^1.15.1",
+            "is-glob": "^3.0.0",
+            "lodash": "^4.16.2",
+            "micromatch": "^2.3.11"
           },
           "dependencies": {
             "is-extglob": {
@@ -7105,7 +7105,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.0"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -7115,9 +7115,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.3.1",
-            "sshpk": "1.10.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "https-browserify": {
@@ -7165,8 +7165,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -7179,19 +7179,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.0.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.1.0",
-            "figures": "1.7.0",
-            "lodash": "4.16.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           }
         },
         "interpret": {
@@ -7204,7 +7204,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.2.0"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -7232,7 +7232,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "binary-extensions": "1.7.0"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
@@ -7245,7 +7245,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-ci": {
@@ -7253,7 +7253,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ci-info": "1.0.0"
+            "ci-info": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -7266,7 +7266,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -7284,7 +7284,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -7292,7 +7292,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -7300,7 +7300,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-lower-case": {
@@ -7308,7 +7308,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lower-case": "1.1.3"
+            "lower-case": "^1.1.0"
           }
         },
         "is-my-json-valid": {
@@ -7316,10 +7316,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.0",
-            "xtend": "4.0.1"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "is-number": {
@@ -7327,7 +7327,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.0.4"
+            "kind-of": "^3.0.2"
           }
         },
         "is-path-cwd": {
@@ -7340,7 +7340,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-path-inside": "1.0.0"
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-path-inside": {
@@ -7348,7 +7348,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-plain-obj": {
@@ -7376,7 +7376,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "tryit": "1.0.2"
+            "tryit": "^1.0.1"
           }
         },
         "is-svg": {
@@ -7384,7 +7384,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "html-comment-regex": "1.1.1"
+            "html-comment-regex": "^1.1.0"
           }
         },
         "is-typedarray": {
@@ -7397,7 +7397,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "upper-case": "1.1.3"
+            "upper-case": "^1.1.0"
           }
         },
         "is-utf8": {
@@ -7433,20 +7433,20 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9",
-            "async": "1.5.2",
-            "escodegen": "1.8.1",
-            "esprima": "2.7.3",
-            "glob": "5.0.15",
-            "handlebars": "4.0.5",
-            "js-yaml": "3.6.1",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "once": "1.4.0",
-            "resolve": "1.1.7",
-            "supports-color": "3.1.2",
-            "which": "1.2.11",
-            "wordwrap": "1.0.0"
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "glob": "^5.0.15",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
           },
           "dependencies": {
             "glob": {
@@ -7454,11 +7454,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -7468,18 +7468,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "clone": "1.0.2",
-            "fileset": "0.2.1",
-            "istanbul-lib-coverage": "1.0.0",
-            "istanbul-lib-hook": "1.0.0-alpha.4",
-            "istanbul-lib-instrument": "1.1.4",
-            "istanbul-lib-report": "1.0.0-alpha.3",
-            "istanbul-lib-source-maps": "1.0.2",
-            "istanbul-reports": "1.0.0",
-            "js-yaml": "3.6.1",
-            "mkdirp": "0.5.1",
-            "once": "1.4.0"
+            "async": "1.x",
+            "clone": "^1.0.2",
+            "fileset": "0.2.x",
+            "istanbul-lib-coverage": "^1.0.0-alpha",
+            "istanbul-lib-hook": "^1.0.0-alpha",
+            "istanbul-lib-instrument": "^1.0.0-alpha",
+            "istanbul-lib-report": "^1.0.0-alpha",
+            "istanbul-lib-source-maps": "^1.0.0-alpha",
+            "istanbul-reports": "^1.0.0-alpha",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "once": "1.x"
           }
         },
         "istanbul-lib-coverage": {
@@ -7492,7 +7492,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.3.0"
+            "append-transform": "^0.3.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -7500,12 +7500,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.17.0",
-            "babel-template": "6.16.0",
-            "babel-traverse": "6.16.0",
-            "babel-types": "6.16.0",
-            "babylon": "6.13.0",
-            "istanbul-lib-coverage": "1.0.0"
+            "babel-generator": "^6.11.3",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.9.0",
+            "babel-types": "^6.10.2",
+            "babylon": "^6.8.1",
+            "istanbul-lib-coverage": "^1.0.0"
           }
         },
         "istanbul-lib-report": {
@@ -7513,12 +7513,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "istanbul-lib-coverage": "1.0.0",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "rimraf": "2.5.4",
-            "supports-color": "3.1.2"
+            "async": "^1.4.2",
+            "istanbul-lib-coverage": "^1.0.0-alpha",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "rimraf": "^2.4.3",
+            "supports-color": "^3.1.2"
           }
         },
         "istanbul-lib-source-maps": {
@@ -7526,10 +7526,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.0.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.4",
-            "source-map": "0.5.6"
+            "istanbul-lib-coverage": "^1.0.0-alpha.0",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.4.4",
+            "source-map": "^0.5.3"
           }
         },
         "istanbul-reports": {
@@ -7537,7 +7537,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.5"
+            "handlebars": "^4.0.3"
           }
         },
         "jasmine-check": {
@@ -7545,7 +7545,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "testcheck": "0.1.4"
+            "testcheck": "^0.1.0"
           }
         },
         "jest": {
@@ -7553,7 +7553,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-cli": "16.0.2"
+            "jest-cli": "^16.0.2"
           },
           "dependencies": {
             "callsites": {
@@ -7566,9 +7566,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.0.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "jest-cli": {
@@ -7576,34 +7576,34 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-escapes": "1.4.0",
-                "callsites": "2.0.0",
-                "chalk": "1.1.3",
-                "graceful-fs": "4.1.9",
-                "is-ci": "1.0.10",
-                "istanbul-api": "1.0.0-aplha.10",
-                "istanbul-lib-coverage": "1.0.0",
-                "istanbul-lib-instrument": "1.1.4",
-                "jest-changed-files": "16.0.0",
-                "jest-config": "16.0.2",
-                "jest-environment-jsdom": "16.0.2",
-                "jest-file-exists": "15.0.0",
-                "jest-haste-map": "16.0.2",
-                "jest-jasmine2": "16.0.2",
-                "jest-mock": "16.0.2",
-                "jest-resolve": "16.0.2",
-                "jest-resolve-dependencies": "16.0.2",
-                "jest-runtime": "16.0.2",
-                "jest-snapshot": "16.0.2",
-                "jest-util": "16.0.2",
-                "json-stable-stringify": "1.0.1",
-                "node-notifier": "4.6.1",
-                "sane": "1.4.1",
-                "strip-ansi": "3.0.1",
-                "throat": "3.0.0",
-                "which": "1.2.11",
-                "worker-farm": "1.3.1",
-                "yargs": "5.0.0"
+                "ansi-escapes": "^1.4.0",
+                "callsites": "^2.0.0",
+                "chalk": "^1.1.1",
+                "graceful-fs": "^4.1.6",
+                "is-ci": "^1.0.9",
+                "istanbul-api": "^1.0.0-aplha.10",
+                "istanbul-lib-coverage": "^1.0.0",
+                "istanbul-lib-instrument": "^1.1.1",
+                "jest-changed-files": "^16.0.0",
+                "jest-config": "^16.0.2",
+                "jest-environment-jsdom": "^16.0.2",
+                "jest-file-exists": "^15.0.0",
+                "jest-haste-map": "^16.0.2",
+                "jest-jasmine2": "^16.0.2",
+                "jest-mock": "^16.0.2",
+                "jest-resolve": "^16.0.2",
+                "jest-resolve-dependencies": "^16.0.2",
+                "jest-runtime": "^16.0.2",
+                "jest-snapshot": "^16.0.2",
+                "jest-util": "^16.0.2",
+                "json-stable-stringify": "^1.0.0",
+                "node-notifier": "^4.6.1",
+                "sane": "~1.4.1",
+                "strip-ansi": "^3.0.1",
+                "throat": "^3.0.0",
+                "which": "^1.1.1",
+                "worker-farm": "^1.3.1",
+                "yargs": "^5.0.0"
               }
             },
             "window-size": {
@@ -7616,20 +7616,20 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "3.2.0"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.2.0",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^3.2.0"
               }
             }
           }
@@ -7644,15 +7644,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "istanbul": "0.4.5",
-            "jest-environment-jsdom": "16.0.2",
-            "jest-environment-node": "16.0.2",
-            "jest-jasmine2": "16.0.2",
-            "jest-mock": "16.0.2",
-            "jest-resolve": "16.0.2",
-            "jest-util": "16.0.2",
-            "json-stable-stringify": "1.0.1"
+            "chalk": "^1.1.1",
+            "istanbul": "^0.4.5",
+            "jest-environment-jsdom": "^16.0.2",
+            "jest-environment-node": "^16.0.2",
+            "jest-jasmine2": "^16.0.2",
+            "jest-mock": "^16.0.2",
+            "jest-resolve": "^16.0.2",
+            "jest-util": "^16.0.2",
+            "json-stable-stringify": "^1.0.0"
           }
         },
         "jest-diff": {
@@ -7660,10 +7660,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.0.1",
-            "jest-matcher-utils": "16.0.0",
-            "pretty-format": "4.2.1"
+            "chalk": "^1.1.3",
+            "diff": "^3.0.0",
+            "jest-matcher-utils": "^16.0.0",
+            "pretty-format": "~4.2.1"
           }
         },
         "jest-environment-jsdom": {
@@ -7671,9 +7671,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-mock": "16.0.2",
-            "jest-util": "16.0.2",
-            "jsdom": "9.8.0"
+            "jest-mock": "^16.0.2",
+            "jest-util": "^16.0.2",
+            "jsdom": "^9.8.0"
           }
         },
         "jest-environment-node": {
@@ -7681,8 +7681,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-mock": "16.0.2",
-            "jest-util": "16.0.2"
+            "jest-mock": "^16.0.2",
+            "jest-util": "^16.0.2"
           }
         },
         "jest-file-exists": {
@@ -7695,10 +7695,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fb-watchman": "1.9.0",
-            "graceful-fs": "4.1.9",
-            "multimatch": "2.1.0",
-            "worker-farm": "1.3.1"
+            "fb-watchman": "^1.9.0",
+            "graceful-fs": "^4.1.6",
+            "multimatch": "^2.1.0",
+            "worker-farm": "^1.3.1"
           }
         },
         "jest-jasmine2": {
@@ -7706,11 +7706,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "jasmine-check": "0.1.5",
-            "jest-matchers": "16.0.2",
-            "jest-snapshot": "16.0.2",
-            "jest-util": "16.0.2"
+            "graceful-fs": "^4.1.6",
+            "jasmine-check": "^0.1.4",
+            "jest-matchers": "^16.0.2",
+            "jest-snapshot": "^16.0.2",
+            "jest-util": "^16.0.2"
           }
         },
         "jest-matcher-utils": {
@@ -7718,8 +7718,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "pretty-format": "4.2.1"
+            "chalk": "^1.1.3",
+            "pretty-format": "~4.2.1"
           }
         },
         "jest-matchers": {
@@ -7727,9 +7727,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-diff": "16.0.0",
-            "jest-matcher-utils": "16.0.0",
-            "jest-util": "16.0.2"
+            "jest-diff": "^16.0.0",
+            "jest-matcher-utils": "^16.0.0",
+            "jest-util": "^16.0.2"
           }
         },
         "jest-mock": {
@@ -7742,10 +7742,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "browser-resolve": "1.11.2",
-            "jest-file-exists": "15.0.0",
-            "jest-haste-map": "16.0.2",
-            "resolve": "1.1.7"
+            "browser-resolve": "^1.11.2",
+            "jest-file-exists": "^15.0.0",
+            "jest-haste-map": "^16.0.2",
+            "resolve": "^1.1.6"
           }
         },
         "jest-resolve-dependencies": {
@@ -7753,8 +7753,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-file-exists": "15.0.0",
-            "jest-resolve": "16.0.2"
+            "jest-file-exists": "^15.0.0",
+            "jest-resolve": "^16.0.2"
           }
         },
         "jest-runtime": {
@@ -7762,21 +7762,21 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-core": "6.17.0",
-            "babel-jest": "16.0.0",
-            "babel-plugin-istanbul": "2.0.3",
-            "chalk": "1.1.3",
-            "graceful-fs": "4.1.9",
-            "jest-config": "16.0.2",
-            "jest-file-exists": "15.0.0",
-            "jest-haste-map": "16.0.2",
-            "jest-mock": "16.0.2",
-            "jest-resolve": "16.0.2",
-            "jest-snapshot": "16.0.2",
-            "jest-util": "16.0.2",
-            "json-stable-stringify": "1.0.1",
-            "multimatch": "2.1.0",
-            "yargs": "5.0.0"
+            "babel-core": "^6.11.4",
+            "babel-jest": "^16.0.0",
+            "babel-plugin-istanbul": "^2.0.0",
+            "chalk": "^1.1.3",
+            "graceful-fs": "^4.1.6",
+            "jest-config": "^16.0.2",
+            "jest-file-exists": "^15.0.0",
+            "jest-haste-map": "^16.0.2",
+            "jest-mock": "^16.0.2",
+            "jest-resolve": "^16.0.2",
+            "jest-snapshot": "^16.0.2",
+            "jest-util": "^16.0.2",
+            "json-stable-stringify": "^1.0.0",
+            "multimatch": "^2.1.0",
+            "yargs": "^5.0.0"
           },
           "dependencies": {
             "cliui": {
@@ -7784,9 +7784,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.0.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "window-size": {
@@ -7799,20 +7799,20 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "3.2.0"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.2.0",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^3.2.0"
               }
             }
           }
@@ -7822,12 +7822,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jest-diff": "16.0.0",
-            "jest-file-exists": "15.0.0",
-            "jest-matcher-utils": "16.0.0",
-            "jest-util": "16.0.2",
-            "natural-compare": "1.4.0",
-            "pretty-format": "4.2.1"
+            "jest-diff": "^16.0.0",
+            "jest-file-exists": "^15.0.0",
+            "jest-matcher-utils": "^16.0.0",
+            "jest-util": "^16.0.2",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "~4.2.1"
           }
         },
         "jest-util": {
@@ -7835,12 +7835,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.0.1",
-            "graceful-fs": "4.1.9",
-            "jest-file-exists": "15.0.0",
-            "jest-mock": "16.0.2",
-            "mkdirp": "0.5.1"
+            "chalk": "^1.1.1",
+            "diff": "^3.0.0",
+            "graceful-fs": "^4.1.6",
+            "jest-file-exists": "^15.0.0",
+            "jest-mock": "^16.0.2",
+            "mkdirp": "^0.5.1"
           }
         },
         "jodid25519": {
@@ -7849,7 +7849,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.0"
+            "jsbn": "~0.1.0"
           }
         },
         "js-base64": {
@@ -7867,8 +7867,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "jsbn": {
@@ -7882,26 +7882,26 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abab": "1.0.3",
-            "acorn": "2.7.0",
-            "acorn-globals": "1.0.9",
-            "array-equal": "1.0.0",
-            "content-type-parser": "1.0.1",
-            "cssom": "0.3.1",
-            "cssstyle": "0.2.37",
-            "escodegen": "1.8.1",
-            "html-encoding-sniffer": "1.0.1",
-            "iconv-lite": "0.4.13",
-            "nwmatcher": "1.3.8",
-            "parse5": "1.5.1",
-            "request": "2.75.0",
-            "sax": "1.2.1",
-            "symbol-tree": "3.1.4",
-            "tough-cookie": "2.3.1",
-            "webidl-conversions": "3.0.1",
-            "whatwg-encoding": "1.0.1",
-            "whatwg-url": "3.0.0",
-            "xml-name-validator": "2.0.1"
+            "abab": "^1.0.0",
+            "acorn": "^2.4.0",
+            "acorn-globals": "^1.0.4",
+            "array-equal": "^1.0.0",
+            "content-type-parser": "^1.0.1",
+            "cssom": ">= 0.3.0 < 0.4.0",
+            "cssstyle": ">= 0.2.36 < 0.3.0",
+            "escodegen": "^1.6.1",
+            "html-encoding-sniffer": "^1.0.1",
+            "iconv-lite": "^0.4.13",
+            "nwmatcher": ">= 1.3.7 < 2.0.0",
+            "parse5": "^1.5.1",
+            "request": "^2.55.0",
+            "sax": "^1.1.4",
+            "symbol-tree": ">= 3.1.0 < 4.0.0",
+            "tough-cookie": "^2.3.1",
+            "webidl-conversions": "^3.0.1",
+            "whatwg-encoding": "^1.0.1",
+            "whatwg-url": "^3.0.0",
+            "xml-name-validator": ">= 2.0.1 < 3.0.0"
           },
           "dependencies": {
             "acorn": {
@@ -7931,7 +7931,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -7954,7 +7954,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9"
+            "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
@@ -7982,8 +7982,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "acorn-jsx": "3.0.1",
-            "object-assign": "4.1.0"
+            "acorn-jsx": "^3.0.1",
+            "object-assign": "^4.1.0"
           }
         },
         "kind-of": {
@@ -7991,7 +7991,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.4"
+            "is-buffer": "^1.0.2"
           }
         },
         "klaw": {
@@ -8009,7 +8009,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "levn": {
@@ -8017,8 +8017,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
           }
         },
         "load-json-file": {
@@ -8026,11 +8026,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "loader-utils": {
@@ -8038,10 +8038,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.0",
-            "object-assign": "4.1.0"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           },
           "dependencies": {
             "json5": {
@@ -8071,8 +8071,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         },
         "lodash._baseclone": {
@@ -8080,12 +8080,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._arraycopy": "3.0.0",
-            "lodash._arrayeach": "3.0.0",
-            "lodash._baseassign": "3.2.0",
-            "lodash._basefor": "3.0.3",
-            "lodash.isarray": "3.0.4",
-            "lodash.keys": "3.1.2"
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._baseassign": "^3.0.0",
+            "lodash._basefor": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         },
         "lodash._basecopy": {
@@ -8108,8 +8108,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash.deburr": "3.2.0",
-            "lodash.words": "3.2.0"
+            "lodash.deburr": "^3.0.0",
+            "lodash.words": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -8132,7 +8132,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._createcompounder": "3.0.0"
+            "lodash._createcompounder": "^3.0.0"
           }
         },
         "lodash.clonedeep": {
@@ -8140,8 +8140,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseclone": "3.3.0",
-            "lodash._bindcallback": "3.0.1"
+            "lodash._baseclone": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0"
           }
         },
         "lodash.cond": {
@@ -8154,7 +8154,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._root": "3.0.1"
+            "lodash._root": "^3.0.0"
           }
         },
         "lodash.indexof": {
@@ -8177,9 +8177,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "lodash.pickby": {
@@ -8192,7 +8192,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._root": "3.0.1"
+            "lodash._root": "^3.0.0"
           }
         },
         "longest": {
@@ -8205,7 +8205,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "1.0.3"
+            "js-tokens": "^1.0.1"
           },
           "dependencies": {
             "js-tokens": {
@@ -8225,7 +8225,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lower-case": "1.1.3"
+            "lower-case": "^1.1.2"
           }
         },
         "lru-cache": {
@@ -8233,8 +8233,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.0.0"
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
           }
         },
         "macaddress": {
@@ -8247,7 +8247,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "tmpl": "1.0.4"
+            "tmpl": "1.0.x"
           }
         },
         "marked": {
@@ -8260,11 +8260,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cardinal": "1.0.0",
-            "chalk": "1.1.3",
-            "cli-table": "0.3.1",
-            "lodash.assign": "4.2.0",
-            "node-emoji": "1.4.1"
+            "cardinal": "^1.0.0",
+            "chalk": "^1.0.0",
+            "cli-table": "^0.3.1",
+            "lodash.assign": "^4.2.0",
+            "node-emoji": "^1.3.1"
           }
         },
         "math-expression-evaluator": {
@@ -8272,7 +8272,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash.indexof": "4.0.5"
+            "lodash.indexof": "^4.0.5"
           }
         },
         "media-typer": {
@@ -8285,8 +8285,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
-            "readable-stream": "2.0.6"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "merge": {
@@ -8309,19 +8309,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.0",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.0.4",
-            "normalize-path": "2.0.1",
-            "object.omit": "2.0.0",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mime": {
@@ -8339,7 +8339,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.24.0"
+            "mime-db": "~1.24.0"
           }
         },
         "minimatch": {
@@ -8347,7 +8347,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -8380,10 +8380,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-differ": "1.0.0",
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "minimatch": "3.0.3"
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
           }
         },
         "mute-stream": {
@@ -8407,7 +8407,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "xml-char-classes": "1.0.0"
+            "xml-char-classes": "^1.0.0"
           }
         },
         "negotiator": {
@@ -8420,7 +8420,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lower-case": "1.1.3"
+            "lower-case": "^1.1.1"
           }
         },
         "node-emoji": {
@@ -8428,7 +8428,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string.prototype.codepointat": "0.2.0"
+            "string.prototype.codepointat": "^0.2.0"
           }
         },
         "node-int64": {
@@ -8441,28 +8441,28 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assert": "1.4.1",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "console-browserify": "1.1.0",
+            "assert": "^1.1.1",
+            "browserify-zlib": "~0.1.4",
+            "buffer": "^4.9.0",
+            "console-browserify": "^1.1.0",
             "constants-browserify": "0.0.1",
-            "crypto-browserify": "3.2.8",
-            "domain-browser": "1.1.7",
-            "events": "1.1.1",
-            "http-browserify": "1.7.0",
+            "crypto-browserify": "~3.2.6",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "http-browserify": "^1.3.2",
             "https-browserify": "0.0.0",
-            "os-browserify": "0.1.2",
+            "os-browserify": "~0.1.2",
             "path-browserify": "0.0.0",
-            "process": "0.11.9",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "readable-stream": "1.1.14",
-            "stream-browserify": "1.0.0",
-            "string_decoder": "0.10.31",
-            "timers-browserify": "1.4.2",
+            "process": "^0.11.0",
+            "punycode": "^1.2.4",
+            "querystring-es3": "~0.2.0",
+            "readable-stream": "^1.1.13",
+            "stream-browserify": "^1.0.0",
+            "string_decoder": "~0.10.25",
+            "timers-browserify": "^1.0.1",
             "tty-browserify": "0.0.0",
-            "url": "0.10.3",
-            "util": "0.10.3",
+            "url": "~0.10.1",
+            "util": "~0.10.3",
             "vm-browserify": "0.0.4"
           },
           "dependencies": {
@@ -8476,10 +8476,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             }
           }
@@ -8489,13 +8489,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cli-usage": "0.1.4",
-            "growly": "1.3.0",
-            "lodash.clonedeep": "3.0.2",
-            "minimist": "1.2.0",
-            "semver": "5.3.0",
-            "shellwords": "0.1.0",
-            "which": "1.2.11"
+            "cli-usage": "^0.1.1",
+            "growly": "^1.2.0",
+            "lodash.clonedeep": "^3.0.0",
+            "minimist": "^1.1.1",
+            "semver": "^5.1.0",
+            "shellwords": "^0.1.0",
+            "which": "^1.0.5"
           }
         },
         "node-uuid": {
@@ -8508,7 +8508,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           }
         },
         "normalize-package-data": {
@@ -8516,10 +8516,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -8537,10 +8537,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-assign": "4.1.0",
-            "prepend-http": "1.0.4",
-            "query-string": "4.2.3",
-            "sort-keys": "1.1.2"
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
           }
         },
         "nth-check": {
@@ -8548,7 +8548,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boolbase": "1.0.0"
+            "boolbase": "~1.0.0"
           }
         },
         "num2fraction": {
@@ -8581,8 +8581,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "0.1.4",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.3",
+            "is-extendable": "^0.1.1"
           }
         },
         "on-finished": {
@@ -8603,7 +8603,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "onetime": {
@@ -8621,8 +8621,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           },
           "dependencies": {
             "minimist": {
@@ -8642,12 +8642,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.5",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
           }
         },
         "original": {
@@ -8655,7 +8655,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "url-parse": "1.0.5"
+            "url-parse": "1.0.x"
           },
           "dependencies": {
             "url-parse": {
@@ -8663,8 +8663,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "querystringify": "0.0.4",
-                "requires-port": "1.0.0"
+                "querystringify": "0.0.x",
+                "requires-port": "1.0.x"
               }
             }
           }
@@ -8684,7 +8684,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "os-tmpdir": {
@@ -8702,7 +8702,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0"
+            "no-case": "^2.2.0"
           }
         },
         "parse-glob": {
@@ -8710,10 +8710,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.2",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -8721,7 +8721,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.0"
+            "error-ex": "^1.2.0"
           }
         },
         "parse5": {
@@ -8739,8 +8739,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camel-case": "3.0.0",
-            "upper-case-first": "1.1.2"
+            "camel-case": "^3.0.0",
+            "upper-case-first": "^1.1.0"
           }
         },
         "path-browserify": {
@@ -8753,7 +8753,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0"
+            "no-case": "^2.2.0"
           }
         },
         "path-exists": {
@@ -8761,7 +8761,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -8789,9 +8789,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pbkdf2-compat": {
@@ -8814,7 +8814,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -8822,7 +8822,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "pkg-up": {
@@ -8830,7 +8830,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "pluralize": {
@@ -8843,10 +8843,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.1.9",
-            "source-map": "0.5.6",
-            "supports-color": "3.1.2"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.1.2"
           }
         },
         "postcss-calc": {
@@ -8854,9 +8854,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-message-helpers": "2.0.0",
-            "reduce-css-calc": "1.3.0"
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.6"
           }
         },
         "postcss-colormin": {
@@ -8864,9 +8864,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "colormin": "1.1.2",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "colormin": "^1.0.5",
+            "postcss": "^5.0.13",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "postcss-convert-values": {
@@ -8874,8 +8874,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.11",
+            "postcss-value-parser": "^3.1.2"
           }
         },
         "postcss-discard-comments": {
@@ -8883,7 +8883,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.14"
           }
         },
         "postcss-discard-duplicates": {
@@ -8891,7 +8891,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-discard-empty": {
@@ -8899,7 +8899,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.14"
           }
         },
         "postcss-discard-overridden": {
@@ -8907,7 +8907,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.16"
           }
         },
         "postcss-discard-unused": {
@@ -8915,8 +8915,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "uniqs": "2.0.0"
+            "postcss": "^5.0.14",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-filter-plugins": {
@@ -8924,8 +8924,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "uniqid": "4.1.0"
+            "postcss": "^5.0.4",
+            "uniqid": "^4.0.0"
           }
         },
         "postcss-load-config": {
@@ -8933,10 +8933,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cosmiconfig": "2.1.0",
-            "object-assign": "4.1.0",
-            "postcss-load-options": "1.0.2",
-            "postcss-load-plugins": "2.0.0-rc"
+            "cosmiconfig": "^2.1.0",
+            "object-assign": "^4.1.0",
+            "postcss-load-options": "^1.0.2",
+            "postcss-load-plugins": "^2.0.0-rc"
           }
         },
         "postcss-load-options": {
@@ -8944,8 +8944,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cosmiconfig": "2.1.0",
-            "object-assign": "4.1.0"
+            "cosmiconfig": "^2.1.0",
+            "object-assign": "^4.1.0"
           }
         },
         "postcss-load-plugins": {
@@ -8953,8 +8953,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cosmiconfig": "2.1.0",
-            "object-assign": "4.1.0"
+            "cosmiconfig": "^2.1.0",
+            "object-assign": "^4.1.0"
           }
         },
         "postcss-loader": {
@@ -8962,10 +8962,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loader-utils": "0.2.16",
-            "object-assign": "4.1.0",
-            "postcss": "5.2.5",
-            "postcss-load-config": "1.0.0-rc"
+            "loader-utils": "^0.2.16",
+            "object-assign": "^4.1.0",
+            "postcss": "^5.2.4",
+            "postcss-load-config": "^1.0.0-rc"
           }
         },
         "postcss-merge-idents": {
@@ -8973,9 +8973,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has": "1.0.1",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "has": "^1.0.1",
+            "postcss": "^5.0.10",
+            "postcss-value-parser": "^3.1.1"
           }
         },
         "postcss-merge-longhand": {
@@ -8983,7 +8983,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-merge-rules": {
@@ -8991,8 +8991,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "vendors": "1.0.1"
+            "postcss": "^5.0.4",
+            "vendors": "^1.0.0"
           }
         },
         "postcss-message-helpers": {
@@ -9005,9 +9005,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-assign": "4.1.0",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
           }
         },
         "postcss-minify-gradients": {
@@ -9015,8 +9015,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.12",
+            "postcss-value-parser": "^3.3.0"
           }
         },
         "postcss-minify-params": {
@@ -9024,10 +9024,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.2",
+            "postcss-value-parser": "^3.0.2",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-minify-selectors": {
@@ -9035,9 +9035,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.5",
-            "postcss-selector-parser": "2.2.1"
+            "alphanum-sort": "^1.0.2",
+            "postcss": "^5.0.14",
+            "postcss-selector-parser": "^2.0.0"
           }
         },
         "postcss-modules-extract-imports": {
@@ -9045,7 +9045,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-modules-local-by-default": {
@@ -9053,8 +9053,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "css-selector-tokenizer": "0.6.0",
-            "postcss": "5.2.5"
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
           }
         },
         "postcss-modules-scope": {
@@ -9062,8 +9062,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "css-selector-tokenizer": "0.6.0",
-            "postcss": "5.2.5"
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
           }
         },
         "postcss-modules-values": {
@@ -9071,8 +9071,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "icss-replace-symbols": "1.0.2",
-            "postcss": "5.2.5"
+            "icss-replace-symbols": "^1.0.2",
+            "postcss": "^5.0.14"
           }
         },
         "postcss-normalize-charset": {
@@ -9080,7 +9080,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.5"
           }
         },
         "postcss-normalize-url": {
@@ -9088,10 +9088,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-absolute-url": "2.0.0",
-            "normalize-url": "1.7.0",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "is-absolute-url": "^2.0.0",
+            "normalize-url": "^1.4.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "postcss-ordered-values": {
@@ -9099,8 +9099,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.1"
           }
         },
         "postcss-reduce-idents": {
@@ -9108,8 +9108,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
           }
         },
         "postcss-reduce-initial": {
@@ -9117,7 +9117,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-reduce-transforms": {
@@ -9125,8 +9125,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.8",
+            "postcss-value-parser": "^3.0.1"
           }
         },
         "postcss-selector-parser": {
@@ -9134,9 +9134,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "flatten": "1.0.2",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         },
         "postcss-svgo": {
@@ -9144,10 +9144,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-svg": "2.0.1",
-            "postcss": "5.2.5",
-            "postcss-value-parser": "3.3.0",
-            "svgo": "0.7.1"
+            "is-svg": "^2.0.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3",
+            "svgo": "^0.7.0"
           }
         },
         "postcss-unique-selectors": {
@@ -9155,9 +9155,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.5",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-value-parser": {
@@ -9170,8 +9170,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "postcss": "5.2.5",
-            "uniqs": "2.0.0"
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
           }
         },
         "prelude-ls": {
@@ -9194,8 +9194,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "renderkid": "2.0.0",
-            "utila": "0.4.0"
+            "renderkid": "~2.0.0",
+            "utila": "~0.4"
           }
         },
         "pretty-format": {
@@ -9228,7 +9228,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asap": "2.0.5"
+            "asap": "~2.0.3"
           }
         },
         "proxy-addr": {
@@ -9236,7 +9236,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "forwarded": "0.1.0",
+            "forwarded": "~0.1.0",
             "ipaddr.js": "1.1.1"
           }
         },
@@ -9270,8 +9270,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-assign": "4.1.0",
-            "strict-uri-encode": "1.1.0"
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "querystring": {
@@ -9294,8 +9294,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "kind-of": "3.0.4"
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
           }
         },
         "range-parser": {
@@ -9337,11 +9337,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "debug": {
@@ -9362,7 +9362,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "original": "1.0.0"
+                "original": ">=0.0.5"
               }
             },
             "faye-websocket": {
@@ -9370,7 +9370,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "websocket-driver": "0.6.5"
+                "websocket-driver": ">=0.3.6"
               }
             },
             "has-ansi": {
@@ -9378,7 +9378,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "html-entities": {
@@ -9411,8 +9411,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "object-assign": "4.1.0",
-                "pinkie-promise": "2.0.1"
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "original": {
@@ -9420,7 +9420,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "url-parse": "1.0.5"
+                "url-parse": "1.0.x"
               },
               "dependencies": {
                 "url-parse": {
@@ -9428,8 +9428,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "querystringify": "0.0.4",
-                    "requires-port": "1.0.0"
+                    "querystringify": "0.0.x",
+                    "requires-port": "1.0.x"
                   }
                 }
               }
@@ -9444,7 +9444,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               }
             },
             "querystringify": {
@@ -9462,12 +9462,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "2.2.0",
-                "eventsource": "0.1.6",
-                "faye-websocket": "0.7.3",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.1.6"
+                "debug": "^2.1.0",
+                "eventsource": "^0.1.3",
+                "faye-websocket": "~0.7.3",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.0.1"
               }
             },
             "strip-ansi": {
@@ -9475,7 +9475,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "supports-color": {
@@ -9488,8 +9488,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "querystringify": "0.0.4",
-                "requires-port": "1.0.0"
+                "querystringify": "0.0.x",
+                "requires-port": "1.0.x"
               }
             },
             "websocket-driver": {
@@ -9497,7 +9497,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "websocket-extensions": "0.1.1"
+                "websocket-extensions": ">=0.1.1"
               }
             },
             "websocket-extensions": {
@@ -9512,9 +9512,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.5",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -9522,8 +9522,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -9531,12 +9531,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -9544,10 +9544,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "minimatch": "3.0.3",
-            "readable-stream": "2.0.6",
-            "set-immediate-shim": "1.0.1"
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
           }
         },
         "readline2": {
@@ -9555,8 +9555,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.0.1",
-            "is-fullwidth-code-point": "1.0.0",
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
             "mute-stream": "0.0.5"
           }
         },
@@ -9573,7 +9573,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               }
             }
           }
@@ -9583,7 +9583,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "esprima": "2.7.3"
+            "esprima": "~2.7.0"
           }
         },
         "reduce-css-calc": {
@@ -9591,9 +9591,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
-            "math-expression-evaluator": "1.2.14",
-            "reduce-function-call": "1.0.1"
+            "balanced-match": "^0.4.2",
+            "math-expression-evaluator": "^1.2.14",
+            "reduce-function-call": "^1.0.1"
           }
         },
         "reduce-function-call": {
@@ -9601,7 +9601,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.1.0"
+            "balanced-match": "~0.1.0"
           },
           "dependencies": {
             "balanced-match": {
@@ -9626,8 +9626,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3",
-            "is-primitive": "2.0.0"
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
           }
         },
         "regexpu-core": {
@@ -9635,9 +9635,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "regenerate": "1.3.1",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "regjsgen": {
@@ -9650,7 +9650,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           },
           "dependencies": {
             "jsesc": {
@@ -9670,11 +9670,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "css-select": "1.2.0",
-            "dom-converter": "0.1.4",
-            "htmlparser2": "3.3.0",
-            "strip-ansi": "3.0.1",
-            "utila": "0.3.3"
+            "css-select": "^1.1.0",
+            "dom-converter": "~0.1",
+            "htmlparser2": "~3.3.0",
+            "strip-ansi": "^3.0.0",
+            "utila": "~0.3"
           },
           "dependencies": {
             "utila": {
@@ -9699,7 +9699,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -9707,27 +9707,27 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.5.0",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "2.0.0",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.12",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.8.2",
-            "qs": "6.2.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.1",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.0.0",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "require-directory": {
@@ -9750,8 +9750,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
           }
         },
         "requires-port": {
@@ -9774,8 +9774,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "right-align": {
@@ -9783,7 +9783,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -9791,7 +9791,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "^7.0.5"
           }
         },
         "ripemd160": {
@@ -9804,7 +9804,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.3.0"
           }
         },
         "rx-lite": {
@@ -9817,12 +9817,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "exec-sh": "0.2.0",
-            "fb-watchman": "1.9.0",
-            "minimatch": "3.0.3",
-            "minimist": "1.2.0",
-            "walker": "1.0.7",
-            "watch": "0.10.0"
+            "exec-sh": "^0.2.0",
+            "fb-watchman": "^1.8.0",
+            "minimatch": "^3.0.2",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5",
+            "watch": "~0.10.0"
           }
         },
         "sax": {
@@ -9840,19 +9840,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.0",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "1.5.0",
+            "http-errors": "~1.5.0",
             "mime": "1.3.4",
             "ms": "0.7.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.0"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.0"
           },
           "dependencies": {
             "mime": {
@@ -9867,8 +9867,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0",
-            "upper-case-first": "1.1.2"
+            "no-case": "^2.2.0",
+            "upper-case-first": "^1.1.2"
           }
         },
         "serve-index": {
@@ -9876,13 +9876,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "accepts": "1.3.3",
+            "accepts": "~1.3.3",
             "batch": "0.5.3",
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "http-errors": "1.5.0",
-            "mime-types": "2.1.12",
-            "parseurl": "1.3.1"
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "http-errors": "~1.5.0",
+            "mime-types": "~2.1.11",
+            "parseurl": "~1.3.1"
           }
         },
         "serve-static": {
@@ -9890,9 +9890,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.1",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.1",
             "send": "0.14.1"
           }
         },
@@ -9946,7 +9946,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0"
+            "no-case": "^2.2.0"
           }
         },
         "sntp": {
@@ -9954,7 +9954,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sockjs": {
@@ -9962,8 +9962,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "faye-websocket": "0.10.0",
-            "uuid": "2.0.3"
+            "faye-websocket": "^0.10.0",
+            "uuid": "^2.0.2"
           }
         },
         "sockjs-client": {
@@ -9971,12 +9971,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
-            "eventsource": "0.1.6",
-            "faye-websocket": "0.11.0",
-            "inherits": "2.0.3",
-            "json3": "3.3.2",
-            "url-parse": "1.1.6"
+            "debug": "^2.2.0",
+            "eventsource": "~0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.1"
           },
           "dependencies": {
             "faye-websocket": {
@@ -9984,7 +9984,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "websocket-driver": "0.6.5"
+                "websocket-driver": ">=0.5.1"
               }
             }
           }
@@ -9994,7 +9994,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         },
         "source-list-map": {
@@ -10012,7 +10012,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.5.6"
+            "source-map": "^0.5.3"
           }
         },
         "spdx-correct": {
@@ -10020,7 +10020,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -10043,15 +10043,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.0",
-            "dashdash": "1.14.0",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.6",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.0",
-            "tweetnacl": "0.14.3"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -10071,8 +10071,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "1.1.14"
+            "inherits": "~2.0.1",
+            "readable-stream": "^1.0.27-1"
           },
           "dependencies": {
             "isarray": {
@@ -10085,10 +10085,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             }
           }
@@ -10108,9 +10108,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.0.1",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string.prototype.codepointat": {
@@ -10133,7 +10133,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -10141,7 +10141,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-json-comments": {
@@ -10154,7 +10154,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loader-utils": "0.2.16"
+            "loader-utils": "^0.2.7"
           }
         },
         "supports-color": {
@@ -10162,7 +10162,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "svgo": {
@@ -10170,13 +10170,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "coa": "1.0.1",
-            "colors": "1.1.2",
-            "csso": "2.2.1",
-            "js-yaml": "3.6.1",
-            "mkdirp": "0.5.1",
-            "sax": "1.2.1",
-            "whet.extend": "0.9.9"
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.2.1",
+            "js-yaml": "~3.6.1",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
           }
         },
         "swap-case": {
@@ -10184,8 +10184,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lower-case": "1.1.3",
-            "upper-case": "1.1.3"
+            "lower-case": "^1.1.1",
+            "upper-case": "^1.1.1"
           }
         },
         "symbol-tree": {
@@ -10198,12 +10198,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ajv": "4.8.2",
-            "ajv-keywords": "1.1.1",
-            "chalk": "1.1.3",
-            "lodash": "4.16.4",
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.0.0",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
             "slice-ansi": "0.0.4",
-            "string-width": "2.0.0"
+            "string-width": "^2.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -10216,8 +10216,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "3.0.1"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -10232,11 +10232,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.0",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         },
         "testcheck": {
@@ -10264,7 +10264,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "process": "0.11.9"
+            "process": "~0.11.0"
           }
         },
         "title-case": {
@@ -10272,8 +10272,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "no-case": "2.3.0",
-            "upper-case": "1.1.3"
+            "no-case": "^2.2.0",
+            "upper-case": "^1.0.3"
           }
         },
         "tmpl": {
@@ -10327,7 +10327,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2"
+            "prelude-ls": "~1.1.2"
           }
         },
         "type-is": {
@@ -10336,7 +10336,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.12"
+            "mime-types": "~2.1.11"
           }
         },
         "typedarray": {
@@ -10349,10 +10349,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "0.2.10",
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "async": {
@@ -10377,7 +10377,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "macaddress": "0.2.8"
+            "macaddress": "^0.2.8"
           }
         },
         "uniqs": {
@@ -10400,7 +10400,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "upper-case": "1.1.3"
+            "upper-case": "^1.1.1"
           }
         },
         "url": {
@@ -10424,8 +10424,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loader-utils": "0.2.16",
-            "mime": "1.2.11"
+            "loader-utils": "0.2.x",
+            "mime": "1.2.x"
           }
         },
         "url-parse": {
@@ -10433,8 +10433,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
+            "querystringify": "0.0.x",
+            "requires-port": "1.0.x"
           }
         },
         "user-home": {
@@ -10482,8 +10482,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "vary": {
@@ -10517,7 +10517,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "makeerror": "1.0.11"
+            "makeerror": "1.0.x"
           }
         },
         "watch": {
@@ -10530,9 +10530,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "0.9.2",
-            "chokidar": "1.6.1",
-            "graceful-fs": "4.1.9"
+            "async": "^0.9.0",
+            "chokidar": "^1.0.0",
+            "graceful-fs": "^4.1.2"
           },
           "dependencies": {
             "async": {
@@ -10552,21 +10552,21 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "acorn": "3.3.0",
-            "async": "1.5.2",
-            "clone": "1.0.2",
-            "enhanced-resolve": "0.9.1",
-            "interpret": "0.6.6",
-            "loader-utils": "0.2.16",
-            "memory-fs": "0.3.0",
-            "mkdirp": "0.5.1",
-            "node-libs-browser": "0.6.0",
-            "optimist": "0.6.1",
-            "supports-color": "3.1.2",
-            "tapable": "0.1.10",
-            "uglify-js": "2.6.4",
-            "watchpack": "0.2.9",
-            "webpack-core": "0.6.8"
+            "acorn": "^3.0.0",
+            "async": "^1.3.0",
+            "clone": "^1.0.2",
+            "enhanced-resolve": "~0.9.0",
+            "interpret": "^0.6.4",
+            "loader-utils": "^0.2.11",
+            "memory-fs": "~0.3.0",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": "^0.6.0",
+            "optimist": "~0.6.0",
+            "supports-color": "^3.1.0",
+            "tapable": "~0.1.8",
+            "uglify-js": "~2.6.0",
+            "watchpack": "^0.2.1",
+            "webpack-core": "~0.6.0"
           },
           "dependencies": {
             "acorn": {
@@ -10579,10 +10579,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "async": "~0.2.6",
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
               },
               "dependencies": {
                 "async": {
@@ -10599,8 +10599,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-list-map": "0.1.6",
-            "source-map": "0.4.4"
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.4.1"
           },
           "dependencies": {
             "source-map": {
@@ -10608,7 +10608,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.0"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -10618,10 +10618,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "memory-fs": "0.3.0",
-            "mime": "1.3.4",
-            "path-is-absolute": "1.0.1",
-            "range-parser": "1.2.0"
+            "memory-fs": "~0.3.0",
+            "mime": "^1.3.4",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3"
           },
           "dependencies": {
             "mime": {
@@ -10636,19 +10636,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "compression": "1.6.2",
-            "connect-history-api-fallback": "1.3.0",
-            "express": "4.14.0",
-            "http-proxy-middleware": "0.17.2",
+            "compression": "^1.5.2",
+            "connect-history-api-fallback": "^1.3.0",
+            "express": "^4.13.3",
+            "http-proxy-middleware": "~0.17.1",
             "open": "0.0.5",
-            "optimist": "0.6.1",
-            "serve-index": "1.8.0",
-            "sockjs": "0.3.18",
-            "sockjs-client": "1.1.1",
-            "stream-cache": "0.0.2",
-            "strip-ansi": "3.0.1",
-            "supports-color": "3.1.2",
-            "webpack-dev-middleware": "1.8.4"
+            "optimist": "~0.6.1",
+            "serve-index": "^1.7.2",
+            "sockjs": "^0.3.15",
+            "sockjs-client": "^1.0.3",
+            "stream-cache": "~0.0.1",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^3.1.1",
+            "webpack-dev-middleware": "^1.4.0"
           }
         },
         "webpack-manifest-plugin": {
@@ -10656,8 +10656,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs-extra": "0.30.0",
-            "lodash": "4.16.4"
+            "fs-extra": "^0.30.0",
+            "lodash": ">=3.5 <5"
           }
         },
         "webpack-sources": {
@@ -10665,8 +10665,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-list-map": "0.1.6",
-            "source-map": "0.5.6"
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.5.3"
           }
         },
         "websocket-driver": {
@@ -10674,7 +10674,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "websocket-extensions": "0.1.1"
+            "websocket-extensions": ">=0.1.1"
           }
         },
         "websocket-extensions": {
@@ -10700,8 +10700,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "tr46": "0.0.3",
-            "webidl-conversions": "3.0.1"
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
           }
         },
         "whet.extend": {
@@ -10714,7 +10714,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "1.1.2"
+            "isexe": "^1.1.1"
           }
         },
         "which-module": {
@@ -10737,8 +10737,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
-            "xtend": "4.0.1"
+            "errno": ">=0.1.1 <0.2.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "wrap-ansi": {
@@ -10746,7 +10746,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.1"
           }
         },
         "wrappy": {
@@ -10759,7 +10759,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mkdirp": "0.5.1"
+            "mkdirp": "^0.5.1"
           }
         },
         "xml-char-classes": {
@@ -10792,9 +10792,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         },
@@ -10803,8 +10803,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -10822,13 +10822,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -10845,8 +10845,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -10856,7 +10856,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.8.1"
+        "resolve": "^1.1.6"
       }
     },
     "regenerator-runtime": {
@@ -10870,8 +10870,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -10880,7 +10880,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -10895,8 +10895,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -10905,7 +10905,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -10914,7 +10914,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -10941,18 +10941,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -10969,9 +10969,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -10992,9 +10992,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "slice-ansi": {
@@ -11012,7 +11012,7 @@
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "2.3.3",
-        "engine.io-client": "1.8.5",
+        "engine.io-client": "~1.8.4",
         "has-binary": "0.1.7",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
@@ -11090,9 +11090,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -11101,7 +11101,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -11110,7 +11110,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -11137,12 +11137,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.11",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11163,8 +11163,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -11173,7 +11173,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -11201,7 +11201,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -11211,7 +11211,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.20"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -11235,7 +11235,7 @@
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
       "integrity": "sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=",
       "requires": {
-        "invariant": "2.2.4"
+        "invariant": "^2.1.0"
       }
     },
     "unpipe": {
@@ -11250,7 +11250,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -11276,7 +11276,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "whatwg-fetch": {
@@ -11302,7 +11302,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {
@@ -11310,8 +11310,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "wtf-8": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,44 +5,29 @@
   "requires": true,
   "dependencies": {
     "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.16",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "requires": {
-            "mime-db": "~1.30.0"
-          }
-        }
       }
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -51,7 +36,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -77,6 +62,13 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -122,21 +114,24 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-      "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "anymatch": {
       "version": "2.0.0",
@@ -149,8 +144,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -176,23 +172,8 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -205,16 +186,16 @@
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -223,9 +204,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "^4.14.0"
       }
@@ -264,12 +245,6 @@
         "js-tokens": "^3.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -278,7 +253,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -289,23 +264,11 @@
             "supports-color": "^2.0.0"
           }
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -341,12 +304,6 @@
         "pascalcase": "^0.1.1"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "define-property": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -412,50 +369,30 @@
       "dev": true
     },
     "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        }
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
       }
     },
     "boxen": {
@@ -477,32 +414,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -528,15 +439,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -587,18 +489,31 @@
       "dev": true
     },
     "bson": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "buffer-shims": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "bytes": {
       "version": "3.0.0",
@@ -620,14 +535,6 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        }
       }
     },
     "caller-path": {
@@ -646,7 +553,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -671,59 +578,34 @@
         "assertion-error": "^1.0.1",
         "deep-eql": "^0.1.3",
         "type-detect": "^1.0.0"
-      },
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-          "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-          "dev": true
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
-            }
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
-        }
       }
     },
     "chalk": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-      "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^1.1.0",
-        "escape-string-regexp": "^1.0.0",
-        "has-ansi": "^0.1.0",
-        "strip-ansi": "^0.3.0",
-        "supports-color": "^0.2.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-          "dev": true
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chokidar": {
       "version": "2.0.4",
@@ -840,9 +722,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -850,7 +732,7 @@
     },
     "commander": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
       "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
       "dev": true
     },
@@ -871,56 +753,33 @@
     },
     "concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "concurrently": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz",
-      "integrity": "sha1-jPG3cHppFqeKT/W3e7BN7FSzebI=",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.6.1.tgz",
+      "integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
+        "chalk": "^2.4.1",
         "commander": "2.6.0",
         "date-fns": "^1.23.0",
         "lodash": "^4.5.1",
+        "read-pkg": "^3.0.0",
         "rx": "2.3.24",
         "spawn-command": "^0.0.2-1",
         "supports-color": "^3.2.3",
@@ -953,6 +812,7 @@
     },
     "cookie": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-parser": {
@@ -962,22 +822,11 @@
       "requires": {
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        },
-        "cookie-signature": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-        }
       }
     },
     "cookie-signature": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
@@ -994,11 +843,12 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-error-class": {
@@ -1011,9 +861,9 @@
       }
     },
     "create-react-class": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
@@ -1031,6 +881,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -1039,7 +894,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -1047,26 +902,17 @@
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
     "debug": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-      "dev": true,
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
-        "ms": "^2.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
+        "ms": "2.0.0"
       }
     },
     "decode-uri-component": {
@@ -1074,6 +920,23 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -1083,8 +946,18 @@
     },
     "deep-is": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -1127,21 +1000,6 @@
         }
       }
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1149,9 +1007,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -1165,13 +1023,12 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "^2.0.2"
       }
     },
     "dot-prop": {
@@ -1185,14 +1042,8 @@
     },
     "dotenv": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1214,9 +1065,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.12",
@@ -1227,16 +1078,16 @@
       }
     },
     "engine.io": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
-      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
         "debug": "~3.1.0",
         "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "ws": "~6.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1250,9 +1101,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-      "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.1.tgz",
+      "integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1262,7 +1113,7 @@
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
+        "ws": "~6.1.0",
         "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
@@ -1278,25 +1129,59 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
+        "blob": "0.0.5",
         "has-binary2": "~1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.35",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "~3.1.1"
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.46",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
@@ -1326,7 +1211,7 @@
     },
     "es6-promise": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "es6-set": {
@@ -1374,6 +1259,33 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -1430,12 +1342,6 @@
         "user-home": "^2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -1444,7 +1350,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1453,55 +1359,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1519,9 +1376,9 @@
       "dev": true
     },
     "eslint-plugin-promise": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
-      "integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
       "dev": true
     },
     "eslint-plugin-standard": {
@@ -1531,32 +1388,37 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.4",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.1.1",
+        "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
       }
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1567,6 +1429,7 @@
     },
     "esutils": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
@@ -1583,22 +1446,6 @@
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
-      }
-    },
-    "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-      "dev": true,
-      "requires": {
-        "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
       }
     },
     "execa": {
@@ -1637,15 +1484,6 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -1679,234 +1517,49 @@
         "object-inspect": "^1.1.0",
         "object-keys": "^1.0.9",
         "tmatch": "^2.0.1"
-      },
-      "dependencies": {
-        "define-properties": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-          "dev": true,
-          "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "es-abstract": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.1.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.1",
-            "is-callable": "^1.1.3",
-            "is-regex": "^1.0.4"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "dev": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "is-arrow-function": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-          "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.0.4"
-          }
-        },
-        "is-boolean-object": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-          "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-          "dev": true
-        },
-        "is-date-object": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-          "dev": true
-        },
-        "is-equal": {
-          "version": "1.5.5",
-          "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-          "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1",
-            "is-arrow-function": "^2.0.3",
-            "is-boolean-object": "^1.0.0",
-            "is-callable": "^1.1.3",
-            "is-date-object": "^1.0.1",
-            "is-generator-function": "^1.0.6",
-            "is-number-object": "^1.0.3",
-            "is-regex": "^1.0.3",
-            "is-string": "^1.0.4",
-            "is-symbol": "^1.0.1",
-            "object.entries": "^1.0.4"
-          }
-        },
-        "is-generator-function": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-          "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
-          "dev": true
-        },
-        "is-number-object": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-          "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.1"
-          }
-        },
-        "is-string": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-          "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-          "dev": true
-        },
-        "is-symbol": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.0"
-          }
-        },
-        "object-inspect": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.0.12",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-          "dev": true
-        },
-        "object.entries": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-          "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.2",
-            "es-abstract": "^1.6.1",
-            "function-bind": "^1.1.0",
-            "has": "^1.0.1"
-          }
-        },
-        "tmatch": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-          "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
-          "dev": true
-        }
       }
     },
     "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
+        "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
         "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "encodeurl": "~1.0.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.1.0",
+        "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
         "on-finished": "~2.3.0",
         "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.2",
-        "qs": "6.5.1",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
         "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.3.1",
-        "type-is": "~1.6.15",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
@@ -2003,14 +1656,15 @@
       }
     },
     "fast-levenshtein": {
-      "version": "2.0.5",
-      "integrity": "sha1-vTMUV0RRmrHDbD7p8x8I6QebZ/I=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -2018,7 +1672,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "ua-parser-js": "^0.7.18"
       }
     },
     "figures": {
@@ -2065,56 +1719,37 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
-      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
+        "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
         "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
+        "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "flatmap-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.0.tgz",
-      "integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==",
-      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2123,13 +1758,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -2158,12 +1793,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2183,24 +1812,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2210,12 +1843,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2224,34 +1859,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2260,25 +1901,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2287,13 +1932,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2309,7 +1956,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2323,13 +1971,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2338,7 +1988,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2347,7 +1998,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2357,18 +2009,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2376,13 +2031,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2390,12 +2047,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -2404,7 +2063,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2413,7 +2073,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2421,13 +2082,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2438,7 +2101,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2456,7 +2120,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2466,13 +2131,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2482,7 +2149,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2494,18 +2162,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -2513,19 +2184,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2535,19 +2209,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2559,7 +2236,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2567,7 +2245,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2582,7 +2261,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2591,42 +2271,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -2636,7 +2323,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2645,7 +2333,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2653,13 +2342,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2674,13 +2365,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2689,21 +2382,32 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
@@ -2716,7 +2420,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2727,9 +2431,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2738,33 +2442,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -2803,23 +2480,9 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -2837,9 +2500,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "growl": {
@@ -2848,13 +2511,42 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "has-ansi": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-      "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+    "handlebars": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^0.2.0"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -2878,8 +2570,9 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
-      "version": "1.0.0",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
@@ -2927,36 +2620,45 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-      "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
       "dev": true
     },
     "hooks-fixed": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
-      "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz",
+      "integrity": "sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ=="
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "http-errors": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "version": "1.6.3",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.1",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": ">= 1.3.1 < 2"
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
-      "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "ignore-by-default": {
@@ -2984,6 +2686,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2993,6 +2696,7 @@
     },
     "inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
@@ -3003,7 +2707,7 @@
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -3022,12 +2726,6 @@
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -3036,7 +2734,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3045,24 +2743,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -3074,19 +2754,19 @@
       }
     },
     "interpret": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
-      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -3104,6 +2784,21 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-arrow-function": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
+      "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.0.4"
+      }
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -3113,10 +2808,31 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -3130,7 +2846,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -3147,6 +2863,12 @@
           }
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3165,6 +2887,25 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
         }
+      }
+    },
+    "is-equal": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
+      "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "is-arrow-function": "^2.0.3",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.3",
+        "is-date-object": "^1.0.1",
+        "is-generator-function": "^1.0.6",
+        "is-number-object": "^1.0.3",
+        "is-regex": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.1",
+        "object.entries": "^1.0.4"
       }
     },
     "is-extendable": {
@@ -3188,6 +2929,12 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -3207,14 +2954,21 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
         "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
@@ -3245,31 +2999,22 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
+    },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "^1.0.1"
@@ -3296,14 +3041,20 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
-    "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "tryit": "^1.0.1"
+        "has": "^1.0.1"
       }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -3316,6 +3067,21 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3324,6 +3090,7 @@
     },
     "isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
@@ -3369,104 +3136,16 @@
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true,
-          "optional": true
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
         "async": {
           "version": "1.5.2",
           "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-          "dev": true,
-          "requires": {
-            "esprima": "^2.7.1",
-            "estraverse": "^1.9.1",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.2.0"
-          }
-        },
         "esprima": {
           "version": "2.7.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
           "dev": true
         },
         "glob": {
@@ -3482,263 +3161,34 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "handlebars": {
-          "version": "4.0.12",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-          "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
-          "dev": true,
-          "requires": {
-            "async": "^2.5.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.17.10"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-              "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-              "dev": true
-            }
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-              "dev": true
-            }
-          }
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.4",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "wordwrap": "~1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-          "dev": true
-        },
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.17.1",
-            "source-map": "~0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -3762,9 +3212,9 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
-      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
       "requires": {
         "jws": "^3.1.5",
         "lodash.includes": "^4.3.0",
@@ -3825,11 +3275,24 @@
     },
     "levn": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "lodash": {
@@ -3842,6 +3305,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -3879,11 +3347,11 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lowercase-keys": {
@@ -3893,9 +3361,9 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -3909,26 +3377,12 @@
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
       }
     },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "map-visit": {
@@ -3942,7 +3396,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -3952,6 +3406,7 @@
     },
     "methods": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -3976,24 +3431,21 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-      "dev": true
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-      "dev": true,
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "~1.37.0"
       }
     },
     "minimatch": {
@@ -4007,6 +3459,7 @@
     },
     "minimist": {
       "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4033,6 +3486,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4045,9 +3499,9 @@
       "integrity": "sha1-zz2C0YwMp/RY2PKiQIF7PcflSgE="
     },
     "mobx-react": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-4.3.3.tgz",
-      "integrity": "sha1-StdsA9HpQrQx6UL56hjfB1Z3FlU=",
+      "version": "4.4.3",
+      "resolved": "http://registry.npmjs.org/mobx-react/-/mobx-react-4.4.3.tgz",
+      "integrity": "sha1-uqnsQRZe41rnud8ZvKEBkPNvEX4=",
       "dev": true,
       "requires": {
         "hoist-non-react-statics": "^2.3.1"
@@ -4087,11 +3541,19 @@
             "ms": "2.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "supports-color": {
           "version": "5.4.0",
@@ -4105,61 +3567,38 @@
       }
     },
     "mongodb": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
-      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
       "requires": {
         "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.17",
+        "mongodb-core": "2.1.20",
         "readable-stream": "2.2.7"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "mongodb-core": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
-      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
       "requires": {
         "bson": "~1.0.4",
         "require_optional": "~1.0.0"
       }
     },
     "mongoose": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.12.4.tgz",
-      "integrity": "sha512-3QTbQ/+wRe8Lr1IGTBAu2gyx+7VgvnCGmY2N1HSW8nsvfMGO0QW9iNDzZT3ceEY2Wctlt28wNavHivcLDO76bQ==",
+      "version": "4.13.17",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.17.tgz",
+      "integrity": "sha512-VGeSP5O3k9HUXsNm9AocdAlVbfaHV/RHgHc8Jfvwr0D0ZyzgJ3JJ+MKSmz+omicNOhBsmpBEL1zVHM2uIj8tDQ==",
       "requires": {
-        "async": "2.1.4",
+        "async": "2.6.0",
         "bson": "~1.0.4",
-        "hooks-fixed": "2.0.0",
+        "hooks-fixed": "2.0.2",
         "kareem": "1.5.0",
-        "mongodb": "2.2.33",
-        "mpath": "0.3.0",
+        "lodash.get": "4.4.2",
+        "mongodb": "2.2.34",
+        "mpath": "0.5.1",
         "mpromise": "0.5.5",
-        "mquery": "2.3.2",
+        "mquery": "2.3.3",
         "ms": "2.0.0",
         "muri": "1.3.0",
         "regexp-clone": "0.0.1",
@@ -4167,48 +3606,30 @@
       },
       "dependencies": {
         "mongodb": {
-          "version": "2.2.33",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
-          "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
+          "version": "2.2.34",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
+          "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo=",
           "requires": {
             "es6-promise": "3.2.1",
-            "mongodb-core": "2.1.17",
+            "mongodb-core": "2.1.18",
             "readable-stream": "2.2.7"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+        "mongodb-core": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
+          "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA=",
           "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
+            "bson": "~1.0.4",
+            "require_optional": "~1.0.0"
           }
         }
       }
     },
     "mpath": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
-      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
     },
     "mpromise": {
       "version": "0.5.5",
@@ -4216,28 +3637,20 @@
       "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
-      "integrity": "sha512-KXWMypZSvhCuqRtza+HMQZdYw7PfFBjBTFvP31NNAq0OX0/NTIgpcDpkWQ2uTxk6vGQtwQ2elhwhs+ZvCA8OaA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
+      "integrity": "sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "debug": "^2.6.9",
-        "regexp-clone": "^0.0.1",
+        "bluebird": "3.5.0",
+        "debug": "2.6.9",
+        "regexp-clone": "0.0.1",
         "sliced": "0.0.5"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "sliced": {
           "version": "0.0.5",
@@ -4263,9 +3676,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
+      "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==",
       "dev": true,
       "optional": true
     },
@@ -4299,6 +3712,12 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -4309,33 +3728,36 @@
       }
     },
     "nodemon": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz",
-      "integrity": "sha512-hyK6vl65IPnky/ee+D3IWvVGgJa/m3No2/Xc/3wanS6Ce1MWjCzH6NnhPJ/vZM+6JFym16jtHx51lmCMB9HDtg==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
+      "integrity": "sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^2.0.4",
         "debug": "^3.1.0",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.0",
+        "pstree.remy": "^1.1.6",
         "semver": "^5.5.0",
         "supports-color": "^5.2.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.2",
-        "update-notifier": "^2.3.0"
+        "update-notifier": "^2.5.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
         },
-        "semver": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "supports-color": {
@@ -4350,12 +3772,24 @@
       }
     },
     "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
         "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4428,6 +3862,18 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4435,6 +3881,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.pick": {
@@ -4456,6 +3914,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -4464,12 +3923,31 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -4483,7 +3961,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -4503,6 +3981,16 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parseqs": {
@@ -4539,18 +4027,6 @@
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
-      },
-      "dependencies": {
-        "passport-strategy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
-        },
-        "pause": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-          "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
-        }
       }
     },
     "passport-github2": {
@@ -4574,6 +4050,7 @@
     },
     "passport-strategy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "path-dirname": {
@@ -4584,6 +4061,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -4600,9 +4078,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -4610,35 +4088,25 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "pify": "^3.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -4654,6 +4122,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -4665,11 +4134,12 @@
     },
     "process-nextick-args": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
@@ -4682,31 +4152,21 @@
       }
     },
     "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
     },
     "proxy-addr": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
-      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.5.2"
-      }
-    },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
-      "requires": {
-        "event-stream": "~3.3.0"
+        "ipaddr.js": "1.8.0"
       }
     },
     "pseudomap": {
@@ -4716,19 +4176,15 @@
       "dev": true
     },
     "pstree.remy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
-      "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
-      "dev": true,
-      "requires": {
-        "ps-tree": "^1.1.0"
-      }
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "range-parser": {
       "version": "1.2.0",
@@ -4736,13 +4192,13 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       }
     },
@@ -4760,7 +4216,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4789,27 +4245,29 @@
         "prop-types": "^15.5.10"
       }
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+      "requires": {
+        "buffer-shims": "~1.0.0",
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
+        "inherits": "~2.0.1",
         "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
         "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-          "dev": true
-        }
       }
     },
     "readdirp": {
@@ -4891,12 +4349,13 @@
     },
     "repeat-string": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -4922,9 +4381,9 @@
       }
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -4988,23 +4447,28 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
         "ret": "~0.1.10"
       }
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -5016,14 +4480,14 @@
       }
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.1",
+        "depd": "~1.1.2",
         "destroy": "~1.0.4",
-        "encodeurl": "~1.0.1",
+        "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
@@ -5032,43 +4496,25 @@
         "ms": "2.0.0",
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.0",
-        "statuses": "~1.3.1"
+        "statuses": "~1.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.1",
+        "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.2",
-        "send": "0.16.1"
+        "send": "0.16.2"
       }
     },
     "set-value": {
@@ -5100,9 +4546,9 @@
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha1": {
       "version": "1.1.1",
@@ -5111,18 +4557,6 @@
       "requires": {
         "charenc": ">= 0.0.1",
         "crypt": ">= 0.0.1"
-      },
-      "dependencies": {
-        "charenc": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-          "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-        },
-        "crypt": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-          "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-        }
       }
     },
     "shebang-command": {
@@ -5159,7 +4593,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -5184,15 +4618,6 @@
         "use": "^3.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -5210,6 +4635,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -5285,25 +4716,30 @@
       }
     },
     "socket.io": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -5313,23 +4749,23 @@
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
     },
     "socket.io-client": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-      "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
-        "engine.io-client": "~3.2.0",
+        "engine.io-client": "~3.3.1",
         "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.2.0",
+        "socket.io-parser": "~3.3.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -5344,9 +4780,9 @@
       }
     },
     "socket.io-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-      "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
@@ -5369,10 +4805,14 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -5399,14 +4839,37 @@
       "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "through": "2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -5419,6 +4882,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -5444,64 +4908,36 @@
       }
     },
     "statuses": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
-      }
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-      "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^0.2.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5512,7 +4948,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -5538,6 +4974,53 @@
         "mime": "^1.4.1",
         "qs": "^6.5.1",
         "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "supertest": {
@@ -5557,11 +5040,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        }
       }
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -5574,9 +5065,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
@@ -5587,7 +5078,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5596,15 +5087,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -5623,12 +5105,6 @@
             "strip-ansi": "^4.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -5638,15 +5114,6 @@
                 "ansi-regex": "^3.0.0"
               }
             }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -5674,7 +5141,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5682,6 +5149,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "tmatch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
+      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
       "dev": true
     },
     "to-array": {
@@ -5738,50 +5211,47 @@
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
       }
     },
     "tree-kill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
-      "dev": true
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "requires": {
-            "mime-db": "~1.30.0"
-          }
-        }
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -5791,19 +5261,41 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "undefsafe": {
       "version": "2.0.2",
@@ -5812,17 +5304,6 @@
       "dev": true,
       "requires": {
         "debug": "^2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "union-value": {
@@ -5942,43 +5423,6 @@
         "latest-version": "^3.0.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "urix": {
@@ -6013,6 +5457,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
@@ -6020,15 +5465,25 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",
@@ -6040,9 +5495,9 @@
       }
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
         "string-width": "^2.1.1"
@@ -6083,11 +5538,13 @@
     },
     "wordwrap": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -6112,13 +5569,11 @@
       }
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "xdg-basedir": {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -5,7 +5,7 @@ const jwt = require( 'jsonwebtoken' );
 router.get( '/login', passport.authenticate( 'github' ) );
 
 router.get( '/github/callback', passport.authenticate( 'github', { failureRedirect: '/' } ), ( req, res ) => {
-  const token = jwt.sign( req.user, 'super_secret' );
+  const token = jwt.sign( req.user.toJSON(), 'super_secret' );
   console.log( '*' );
   console.log( `*  User ${req.user.username} with GitHub ID ${req.user.gitId} authorized!` );
   console.log( '*' );

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ passport.deserializeUser( ( id, done ) => {
 // Temporary code to test login functionality
 app.get( '/user', authCheck(), ( req, res ) => {
   const data = jwt.decode( req.cookies.token );
-  User.findById( data._doc._id ).then( user => {
+  User.findById( data._id ).then( user => {
     res.status( 201 ).json( { username: user.username } );
   } ).catch( e => res.sendStatus( 400 ) );
 } );


### PR DESCRIPTION
Regenerated package-lock files because of event-stream dependency was causing npm run first command to fail and altered few lines to make application start normally. Fixes issue #46 